### PR TITLE
feat: add extract_text tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# Project Rules
+
+## Overview
+- Use this repository as the source of truth for planning, implementation, and tracking.
+- Keep architecture and product specifics in `docs/`, not hardcoded in this file.
+
+## Coding
+
+### Types
+- Use explicit type hints for all functions, variables, and fields.
+- No `isinstance`/runtime type checks as control flow.
+- No fallback casting; if a type is unknown, fix the design.
+
+### Interfaces
+- Define clear input/output types for every function and module boundary.
+- Avoid passing config dicts into functions; prefer typed models/params.
+- Keep interfaces stable and documented; changes must be explicit.
+
+### Conventions
+- Prefer clear, consistent naming; avoid vague abbreviations.
+- Prefer Pydantic models or dataclasses over loose dicts.
+- Keep functions/modules single-responsibility and focused.
+- Choose an appropriate abstraction level; avoid trivial micro-functions that obscure flow.
+- Avoid tiny one- or two-line helpers; extract only when it improves clarity or reuse.
+
+### Errors and Fallbacks
+- Raise on missing required data or invalid state.
+- Avoid fallbacks whenever possible; prefer hard failures.
+- If a fallback is necessary, always log a warning with enough context to find and fix it later.
+
+## Workflow
+
+### Branching
+- Work must track an issue. If we decide to work on something, it needs an issue. Small non-code housekeeping may skip an issue if approved.
+- Always work on a dedicated branch (never on `main`).
+- When merged, close the linked issue.
+
+### Execution Lifecycle (Required)
+1. Pick one issue as the active task.
+2. Set status to `status:in-progress` when implementation starts.
+3. Open PR with `Closes #<issue_number>` when work is complete.
+4. Merge only after merge-gate checks pass.
+5. After merge: confirm issue is closed, pull `main`, and start the next issue.
+
+### Status Policy (Required)
+- `status:backlog`
+  - Problem and scope are defined.
+  - Required labels are present.
+  - No active implementation branch required.
+- `status:planned`
+  - Acceptance criteria are explicit.
+  - Implementation approach is clear.
+  - Ready to start implementation.
+- `status:in-progress`
+  - Active branch exists and work is ongoing.
+  - Tests are required for changed behavior (new or updated tests).
+  - Run relevant checks locally during implementation (`pnpm run check`, `pnpm run test`).
+- `status:done`
+  - PR is merged to `main`.
+  - Required CI checks are green.
+  - Relevant tests passed for changed scope.
+  - Docs/tracker updated if behavior/process changed.
+  - Local repo synced to latest `main`.
+  - Coverage target met for touched logic (see coverage rule below).
+
+### Coverage Rule (Required)
+- Target: at least `80%` coverage for touched modules and critical branches.
+- Priority focus: core decision logic, data transforms, and failure paths.
+- If automated coverage is not yet wired in CI:
+  - include explicit tests for all important branches in changed code, and
+  - open/follow an issue to enforce numeric coverage in CI before broad scaling.
+
+### Merge Gate (Required Before Merge)
+- Relevant tests must run and pass for changed scope.
+- CI checks for the PR must be green.
+- Docs and tracker updates must be included when behavior/architecture/process changed.
+- No unresolved high-severity review findings.
+- If tests are missing, create/follow an issue to add them before scaling the same area.
+
+### Owner Override
+- Project owner (Jan) can override or bypass any of these rules at their discretion. A direct instruction from the owner in chat is sufficient to proceed.
+
+### Issues
+- Before creating any new issue, ask the user for approval.
+- For any new task/feature/bug, create a GitHub issue first (after approval).
+- Label every new issue using the schema below.
+  - Prefixes: `type:*`, `priority:*`, `status:*`, `area:*`.
+  - Required: exactly one `type:*`, one `priority:*`, one `status:*`, and one or more `area:*`.
+  - Optional: `tech-debt` when it fits.
+  - `type:*` examples: `type:feature`, `type:bug`, `type:refactor`, `type:security`, `type:proposal`.
+  - `area:*` examples: `area:frontend`, `area:backend`, `area:infra`, `area:data`, `area:architecture`, `area:project`.
+  - `priority:*` allowed values: `priority:must`, `priority:should`, `priority:could`, `priority:wont`.
+  - `status:*` allowed values:
+    - `status:backlog` — accepted but not scheduled
+    - `status:planned` — queued/ready to work
+    - `status:in-progress` — actively being worked on
+    - `status:done` — completed and merged/resolved
+- Only close issues with a PR or a clear resolution note.
+- On issue creation, always do all of the following:
+  - apply required labels (`type:*`, `priority:*`, `status:*`, `area:*`)
+  - ensure one valid `status:*` label is present
+- Status sync is automated:
+  - workflow file: `.github/workflows/sync-issue-status-to-project.yml`
+  - automation updates board **Status** from the issue `status:*` label
+- Do not do manual board Status updates for normal flow; only do manual correction if automation fails.
+
+### Privacy Policy
+- Everything in this project is private by default.
+- Keep repository, issues, pull requests, and project boards private.
+- Do not create or convert any project artifact to public visibility unless the user explicitly asks.
+- Assume all planning docs and implementation details are internal-only.
+
+## Tools
+
+### GitHub MCP
+- Default repository: `janthmueller/firefox-devtools-mcp`.
+- Use GitHub MCP for issue and PR operations (search, read, comment, status checks).
+- Write actions (create/update/close issues, PR comments/reviews, merges) require explicit user approval.
+- Do not perform GitHub write actions unless an explicit draft was shown to the user and approved.
+
+### Board Policy (Kanban)
+- Project **Status field** is the workflow source of truth.
+- Required board status columns:
+  - `status:backlog`
+  - `status:planned`
+  - `status:in-progress`
+  - `status:done`
+- Keep issue `status:*` labels as a mirror/filtering aid (not the primary workflow driver).
+- If board status and issue status label differ, board status wins and labels should be updated to match.
+
+### Context/Docs Verification
+- Whenever unsure about a library/API interface, behavior, or response schema, verify against official docs.
+- Prefer verified interfaces over assumptions.
+- Keep queries specific and confirm exact fields/signatures before implementation.
+
+## Documentation Discipline
+- Keep all project docs under `docs/`.
+- Update `docs/README.md` when adding/moving docs.
+- For every meaningful product/tech decision, add or update docs (do not keep key decisions only in chat).
+- Prefer small focused docs by topic (strategy/content/operations/api/tracking).
+- Keep file names explicit and stable; avoid frequent renames.
+- After major updates, reflect status and next steps in `docs/tracking/project_tracker.md`.
+- Keep examples, schemas, and contracts versioned in `docs/` before implementation.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ npx @modelcontextprotocol/inspector npx firefox-devtools-mcp@latest --start-url 
 Then call tools like:
 
 - `list_pages`, `select_page`, `navigate_page`
+- `extract_text` for rendered or DOM text from the page or a scoped region
 - `take_snapshot` then `click_by_uid` / `fill_by_uid`
 - `list_network_requests` (always‑on capture), `get_network_request`
 - `screenshot_page`, `list_console_messages`
@@ -126,6 +127,7 @@ BiDi-dependent features (console events, network events) are not available in co
 ## Tool overview
 
 - Pages: list/new/navigate/select/close
+- Text Extraction: extract rendered or DOM text from the page, selector, or UID
 - Snapshot/UID: take/resolve/clear
 - Input: click/hover/fill/drag/upload/form fill
 - Network: list/get (ID‑first, filters, always‑on capture)
@@ -150,6 +152,15 @@ screenshot_by_uid({ uid: "abc123", saveTo: "/tmp/element.png" })
 The file can then be viewed with Claude Code's `Read` tool without impacting context size.
 
 ## Local development
+
+If you use Nix, enter a dev shell with the required local tools:
+
+```bash
+nix-shell
+npm ci
+```
+
+The shell provides Node.js, npm, Firefox, and geckodriver.
 
 ```bash
 npm install

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    firefox
+    geckodriver
+    git
+    nodejs_22
+  ];
+
+  shellHook = ''
+    export FIREFOX_BIN="${pkgs.firefox}/bin/firefox"
+    export GECKODRIVER_BIN="${pkgs.geckodriver}/bin/geckodriver"
+
+    echo "firefox-devtools-mcp dev shell"
+    echo "Node: $(node --version)"
+    echo "npm: $(npm --version)"
+    echo "Firefox: $(${pkgs.firefox}/bin/firefox --version | head -n 1)"
+  '';
+}

--- a/src/firefox/dom.ts
+++ b/src/firefox/dom.ts
@@ -3,6 +3,7 @@
  */
 
 import { By, Key, WebDriver, WebElement } from 'selenium-webdriver';
+import type { ExtractTextOptions, ExtractTextScope, ExtractTextSource } from './types.js';
 
 export class DomInteractions {
   constructor(
@@ -23,6 +24,71 @@ export class DomInteractions {
   async getContent(): Promise<string> {
     const html = await this.evaluate('return document.documentElement.outerHTML');
     return String(html);
+  }
+
+  async extractText(options: ExtractTextOptions = {}): Promise<string> {
+    const scope: ExtractTextScope = options.scope ?? 'page';
+    const source: ExtractTextSource = options.source ?? 'rendered';
+
+    let targetElement: WebElement | null = null;
+
+    if (scope === 'selector') {
+      const selector = options.selector?.trim();
+      if (!selector) {
+        throw new Error('selector parameter is required when scope="selector"');
+      }
+
+      try {
+        targetElement = await this.driver.executeScript(
+          `
+          const selector = arguments[0];
+          return document.querySelector(selector);
+        `,
+          selector
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Invalid selector syntax: ${message}`);
+      }
+
+      if (!targetElement) {
+        throw new Error(`Element not found for selector: ${selector}`);
+      }
+    }
+
+    if (scope === 'uid') {
+      const uid = options.uid?.trim();
+      if (!uid) {
+        throw new Error('uid parameter is required when scope="uid"');
+      }
+      if (!this.resolveUid) {
+        throw new Error('extractText: resolveUid callback not set. Ensure snapshot is initialized.');
+      }
+      targetElement = await this.resolveUid(uid);
+    }
+
+    const extractedText = await this.driver.executeScript<string>(
+      `
+      const target = arguments[0];
+      const source = arguments[1];
+      const node = target ?? document.body ?? document.documentElement;
+
+      if (!node) {
+        return '';
+      }
+
+      const text =
+        source === 'dom'
+          ? (node.textContent ?? '')
+          : (node instanceof HTMLElement ? node.innerText : node.textContent) ?? '';
+
+      return text.replace(/\\r\\n?/g, '\\n');
+    `,
+      targetElement,
+      source
+    );
+
+    return extractedText;
   }
 
   // ============================================================================

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -2,7 +2,7 @@
  * Firefox Client - Public facade for modular Firefox automation
  */
 
-import type { FirefoxLaunchOptions, ConsoleMessage } from './types.js';
+import type { FirefoxLaunchOptions, ConsoleMessage, ExtractTextOptions } from './types.js';
 import { WebElement } from 'selenium-webdriver';
 import { FirefoxCore } from './core.js';
 import { logDebug } from '../utils/logger.js';
@@ -116,6 +116,13 @@ export class FirefoxClient {
       throw new Error('Not connected');
     }
     return await this.dom.getContent();
+  }
+
+  async extractText(options: ExtractTextOptions = {}): Promise<string> {
+    if (!this.dom) {
+      throw new Error('Not connected');
+    }
+    return await this.dom.extractText(options);
   }
 
   async clickBySelector(selector: string): Promise<void> {

--- a/src/firefox/types.ts
+++ b/src/firefox/types.ts
@@ -47,6 +47,17 @@ export interface NetworkRecord {
   };
 }
 
+export type ExtractTextScope = 'page' | 'selector' | 'uid';
+
+export type ExtractTextSource = 'rendered' | 'dom';
+
+export interface ExtractTextOptions {
+  scope?: ExtractTextScope;
+  selector?: string;
+  uid?: string;
+  source?: ExtractTextSource;
+}
+
 /**
  * Firefox launch options
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,9 @@ const toolHandlers = new Map<string, (input: unknown) => Promise<McpToolResponse
   ['resolve_uid_to_selector', tools.handleResolveUidToSelector],
   ['clear_snapshot', tools.handleClearSnapshot],
 
+  // Text extraction
+  ['extract_text', tools.handleExtractText],
+
   // Input
   ['click_by_uid', tools.handleClickByUid],
   ['hover_by_uid', tools.handleHoverByUid],
@@ -251,6 +254,9 @@ const allTools = [
   tools.takeSnapshotTool,
   tools.resolveUidToSelectorTool,
   tools.clearSnapshotTool,
+
+  // Text extraction
+  tools.extractTextTool,
 
   // Input
   tools.clickByUidTool,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,9 @@ export {
 // Script evaluation tools
 export { evaluateScriptTool, handleEvaluateScript } from './script.js';
 
+// Text extraction tools
+export { extractTextTool, handleExtractText } from './text-extraction.js';
+
 // Console tools
 export {
   listConsoleMessagesTool,

--- a/src/tools/text-extraction.ts
+++ b/src/tools/text-extraction.ts
@@ -1,0 +1,128 @@
+/**
+ * Read-only text extraction tools
+ */
+
+import { errorResponse, successResponse, TOKEN_LIMITS } from '../utils/response-helpers.js';
+import { handleUidError } from '../utils/uid-helpers.js';
+import type { McpToolResponse } from '../types/common.js';
+import type { ExtractTextScope, ExtractTextSource } from '../firefox/types.js';
+
+const DEFAULT_MAX_LENGTH = 20_000;
+
+export const extractTextTool = {
+  name: 'extract_text',
+  description: 'Extract text from the current page or a scoped region.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      scope: {
+        type: 'string',
+        enum: ['page', 'selector', 'uid'],
+        description: 'Extraction scope (default: page)',
+      },
+      selector: {
+        type: 'string',
+        description: 'CSS selector used when scope="selector"',
+      },
+      uid: {
+        type: 'string',
+        description: 'Element UID used when scope="uid"',
+      },
+      source: {
+        type: 'string',
+        enum: ['rendered', 'dom'],
+        description: 'Text source (default: rendered)',
+      },
+      maxLength: {
+        type: 'number',
+        description: 'Maximum characters to return (default: 20000)',
+      },
+    },
+  },
+};
+
+export async function handleExtractText(args: unknown): Promise<McpToolResponse> {
+  try {
+    const {
+      scope = 'page',
+      selector,
+      uid,
+      source = 'rendered',
+      maxLength: requestedMaxLength = DEFAULT_MAX_LENGTH,
+    } = (args as {
+      scope?: ExtractTextScope;
+      selector?: string;
+      uid?: string;
+      source?: ExtractTextSource;
+      maxLength?: number;
+    }) || {};
+
+    if (!['page', 'selector', 'uid'].includes(scope)) {
+      throw new Error('scope must be one of: page, selector, uid');
+    }
+
+    if (!['rendered', 'dom'].includes(source)) {
+      throw new Error('source must be one of: rendered, dom');
+    }
+
+    if (scope === 'selector' && (!selector || typeof selector !== 'string')) {
+      throw new Error('selector parameter is required when scope="selector"');
+    }
+
+    if (scope === 'uid' && (!uid || typeof uid !== 'string')) {
+      throw new Error('uid parameter is required when scope="uid"');
+    }
+
+    if (!Number.isFinite(requestedMaxLength) || requestedMaxLength < 1) {
+      throw new Error('maxLength must be a positive number');
+    }
+
+    const maxLength = Math.min(Math.floor(requestedMaxLength), TOKEN_LIMITS.MAX_RESPONSE_CHARS);
+    const { getFirefox } = await import('../index.js');
+    const firefox = await getFirefox();
+
+    const extractOptions: {
+      scope: ExtractTextScope;
+      source: ExtractTextSource;
+      selector?: string;
+      uid?: string;
+    } = {
+      scope,
+      source,
+    };
+
+    if (selector) {
+      extractOptions.selector = selector;
+    }
+    if (uid) {
+      extractOptions.uid = uid;
+    }
+
+    let extractedText: string;
+    try {
+      extractedText = await firefox.extractText(extractOptions);
+    } catch (error) {
+      if (scope === 'uid' && uid) {
+        throw handleUidError(error as Error, uid);
+      }
+      throw error;
+    }
+
+    const truncated = extractedText.length > maxLength;
+    const outputText = truncated ? extractedText.slice(0, maxLength) : extractedText;
+    let output = `Extracted text [scope=${scope} source=${source} length=${extractedText.length}`;
+    if (truncated) {
+      output += ` returned=${outputText.length} truncated=true`;
+    }
+    output += ']\n\n';
+    output += outputText;
+
+    if (truncated) {
+      output += '\n\n[... truncated]';
+    }
+
+    return successResponse(output);
+  } catch (error) {
+    return errorResponse(error as Error);
+  }
+}

--- a/tests/integration/text-extraction.integration.test.ts
+++ b/tests/integration/text-extraction.integration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration tests for text extraction
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import type { FirefoxClient } from '@/firefox/index.js';
+import {
+  closeFirefox,
+  createTestFirefox,
+  waitForElementInSnapshot,
+  waitForPageLoad,
+} from '../helpers/firefox.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const fixturesPath = resolve(__dirname, '../fixtures');
+
+describe('Text Extraction Integration Tests', () => {
+  let firefox: FirefoxClient;
+
+  beforeAll(async () => {
+    firefox = await createTestFirefox();
+  }, 60000);
+
+  afterAll(async () => {
+    await closeFirefox(firefox);
+  });
+
+  it('should extract rendered text from the current page', async () => {
+    const fixturePath = `file://${fixturesPath}/simple.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const text = await firefox.extractText();
+
+    expect(text).toContain('Simple Test Page');
+    expect(text).toContain('This is a simple test page for Firefox DevTools MCP.');
+    expect(text).toContain('Click Me');
+  }, 10000);
+
+  it('should extract text from a selector-scoped region', async () => {
+    const fixturePath = `file://${fixturesPath}/simple.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const text = await firefox.extractText({
+      scope: 'selector',
+      selector: '#description',
+    });
+
+    expect(text).toBe('This is a simple test page for Firefox DevTools MCP.');
+  }, 10000);
+
+  it('should extract text from a UID-scoped region', async () => {
+    const fixturePath = `file://${fixturesPath}/simple.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const titleUid = await waitForElementInSnapshot(
+      firefox,
+      (entry) => entry.css.includes('#title') || entry.css.includes('id="title"'),
+      10000
+    );
+
+    const text = await firefox.extractText({
+      scope: 'uid',
+      uid: titleUid.uid,
+    });
+
+    expect(text).toBe('Simple Test Page');
+  }, 10000);
+});

--- a/tests/integration/text-extraction.integration.test.ts
+++ b/tests/integration/text-extraction.integration.test.ts
@@ -70,4 +70,53 @@ describe('Text Extraction Integration Tests', () => {
 
     expect(text).toBe('Simple Test Page');
   }, 10000);
+
+  it('should extract DOM text including hidden content when source is dom', async () => {
+    const fixturePath = `file://${fixturesPath}/visibility.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const text = await firefox.extractText({
+      source: 'dom',
+    });
+
+    expect(text).toContain('Hidden Text');
+    expect(text).toContain('Visible Text');
+  }, 10000);
+
+  it('should reject invalid selector syntax', async () => {
+    const fixturePath = `file://${fixturesPath}/simple.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    await expect(
+      firefox.extractText({
+        scope: 'selector',
+        selector: '#description:has(',
+      })
+    ).rejects.toThrow(/Invalid selector syntax/);
+  }, 10000);
+
+  it('should reject stale UIDs after navigation', async () => {
+    const fixturePath = `file://${fixturesPath}/simple.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const snapshot = await firefox.takeSnapshot();
+    const titleUid = snapshot.json.uidMap.find(
+      (entry) => entry.css.includes('#title') || entry.css.includes('id="title"')
+    );
+
+    expect(titleUid).toBeDefined();
+
+    await firefox.navigate(`file://${fixturesPath}/visibility.html`);
+    await waitForPageLoad();
+
+    await expect(
+      firefox.extractText({
+        scope: 'uid',
+        uid: titleUid!.uid,
+      })
+    ).rejects.toThrow(/stale snapshot|UID not found/);
+  }, 10000);
 });

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -65,6 +65,18 @@ describe('Tools Index', () => {
     });
   });
 
+  describe('Text Extraction Tools', () => {
+    it('should export extractTextTool', () => {
+      expect(tools.extractTextTool).toBeDefined();
+      expect(tools.extractTextTool.name).toBe('extract_text');
+    });
+
+    it('should export text extraction handler', () => {
+      expect(tools.handleExtractText).toBeDefined();
+      expect(typeof tools.handleExtractText).toBe('function');
+    });
+  });
+
   describe('Network Tools', () => {
     it('should export listNetworkRequestsTool', () => {
       expect(tools.listNetworkRequestsTool).toBeDefined();

--- a/tests/tools/text-extraction.test.ts
+++ b/tests/tools/text-extraction.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for text extraction tools
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractTextTool, handleExtractText } from '../../src/tools/text-extraction.js';
+
+const mockExtractText = vi.hoisted(() => vi.fn());
+const mockGetFirefox = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/index.js', () => ({
+  getFirefox: () => mockGetFirefox(),
+}));
+
+describe('Text Extraction Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFirefox.mockResolvedValue({
+      extractText: mockExtractText,
+    });
+  });
+
+  describe('Tool Definitions', () => {
+    it('should have correct tool name', () => {
+      expect(extractTextTool.name).toBe('extract_text');
+    });
+
+    it('should have valid description', () => {
+      expect(extractTextTool.description).toContain('Extract text');
+    });
+
+    it('should have valid input schema', () => {
+      expect(extractTextTool.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('Schema Properties', () => {
+    it('should support scope, source, and maxLength', () => {
+      const { properties } = extractTextTool.inputSchema;
+      expect(properties?.scope).toBeDefined();
+      expect(properties?.source).toBeDefined();
+      expect(properties?.maxLength).toBeDefined();
+    });
+
+    it('should support selector and uid scoping', () => {
+      const { properties } = extractTextTool.inputSchema;
+      expect(properties?.selector).toBeDefined();
+      expect(properties?.uid).toBeDefined();
+    });
+  });
+
+  describe('handleExtractText', () => {
+    it('should extract rendered page text by default', async () => {
+      mockExtractText.mockResolvedValue('Visible page text');
+
+      const result = await handleExtractText({});
+
+      expect(mockExtractText).toHaveBeenCalledWith({
+        scope: 'page',
+        selector: undefined,
+        uid: undefined,
+        source: 'rendered',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Visible page text');
+    });
+
+    it('should support selector-scoped DOM extraction', async () => {
+      mockExtractText.mockResolvedValue('Scoped DOM text');
+
+      const result = await handleExtractText({
+        scope: 'selector',
+        selector: '#content',
+        source: 'dom',
+      });
+
+      expect(mockExtractText).toHaveBeenCalledWith({
+        scope: 'selector',
+        selector: '#content',
+        uid: undefined,
+        source: 'dom',
+      });
+      expect(result.content[0].text).toContain('scope=selector');
+      expect(result.content[0].text).toContain('source=dom');
+    });
+
+    it('should truncate output when maxLength is exceeded', async () => {
+      mockExtractText.mockResolvedValue('abcdefghij');
+
+      const result = await handleExtractText({ maxLength: 5 });
+
+      expect(result.content[0].text).toContain('truncated=true');
+      expect(result.content[0].text).toContain('[... truncated]');
+    });
+
+    it('should return an error when selector scope is missing selector', async () => {
+      const result = await handleExtractText({ scope: 'selector' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('selector parameter is required');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only `extract_text` MCP tool for page, selector, and UID-scoped text extraction
- support both `rendered` and `dom` extraction modes without enabling arbitrary script execution
- add a Nix dev shell for local setup and document both the shell and the new tool in the README

## Testing
- `nix-shell --run 'npm run typecheck'`
- `nix-shell --run 'npm run build'`
- `nix-shell --run 'npm run test:run -- tests/tools/text-extraction.test.ts tests/integration/text-extraction.integration.test.ts tests/tools/index.test.ts'`

Closes #1