### PR TITLE
feat: brand and prepare firewatch-mcp for publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,5 @@ ACCEPT_INSECURE_CERTS=false
 # Firefox profile path (optional, for persistent profile)
 FIREFOX_PROFILE_PATH=
 
-# Debug logging (set to * or firefox-devtools for verbose logs)
+# Debug logging (set to * or firewatch for verbose logs)
 DEBUG=

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - 'v*.*.*'
@@ -24,13 +22,6 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org/'
           cache: 'npm'
-          always-auth: true
-
-      - name: Configure npm auth
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: npm ci
@@ -44,5 +35,3 @@ jobs:
 
       - name: Publish
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
         run: npm run test:run
 
       - name: Create archive
-        run: tar -czf firefox-devtools-mcp-${{ github.ref_name }}.tar.gz dist package.json README.md LICENSE
+        run: tar -czf firewatch-mcp-${{ github.ref_name }}.tar.gz dist package.json README.md LICENSE
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: firefox-devtools-mcp-${{ github.ref_name }}.tar.gz
+          files: firewatch-mcp-${{ github.ref_name }}.tar.gz
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@
 ## Tools
 
 ### GitHub MCP
-- Default repository: `janthmueller/firefox-devtools-mcp`.
+- Default repository: `janthmueller/firewatch-mcp`.
 - Use GitHub MCP for issue and PR operations (search, read, comment, status checks).
 - Write actions (create/update/close issues, PR comments/reviews, merges) require explicit user approval.
 - Do not perform GitHub write actions unless an explicit draft was shown to the user and approved.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Firefox DevTools MCP
+# Firewatch MCP
 
-[![npm version](https://badge.fury.io/js/firefox-devtools-mcp.svg)](https://www.npmjs.com/package/firefox-devtools-mcp)
-[![CI](https://github.com/mozilla/firefox-devtools-mcp/workflows/CI/badge.svg)](https://github.com/mozilla/firefox-devtools-mcp/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/mozilla/firefox-devtools-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/mozilla/firefox-devtools-mcp)
+[![npm version](https://badge.fury.io/js/firewatch-mcp.svg)](https://www.npmjs.com/package/firewatch-mcp)
+[![CI](https://github.com/janthmueller/firefox-devtools-mcp/workflows/CI/badge.svg)](https://github.com/janthmueller/firefox-devtools-mcp/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/janthmueller/firefox-devtools-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/janthmueller/firefox-devtools-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-<a href="https://glama.ai/mcp/servers/@mozilla/firefox-devtools-mcp"><img src="https://glama.ai/mcp/servers/@mozilla/firefox-devtools-mcp/badge" height="223" alt="Glama"></a>
+<a href="https://glama.ai/mcp/servers/firewatch-mcp"><img src="https://glama.ai/mcp/servers/firewatch-mcp/badge" height="223" alt="Glama"></a>
 
-Model Context Protocol server for automating Firefox via WebDriver BiDi (through Selenium WebDriver). Works with Claude Code, Claude Desktop, Cursor, Cline and other MCP clients.
+Model Context Protocol server for automating Firefox via WebDriver BiDi (through Selenium WebDriver). Firewatch MCP works with Claude Code, Claude Desktop, Cursor, Cline and other MCP clients.
 
-Repository: https://github.com/mozilla/firefox-devtools-mcp
+Repository: https://github.com/janthmueller/firefox-devtools-mcp
 
-> **Note**: This MCP server requires a local Firefox browser installation and cannot run on cloud hosting services like glama.ai. Use `npx firefox-devtools-mcp@latest` to run locally, or use Docker with the provided Dockerfile.
+> **Note**: This MCP server requires a local Firefox browser installation and cannot run on cloud hosting services like glama.ai. Use `npx firewatch-mcp@latest` to run locally, or use Docker with the provided Dockerfile.
 
 ## Requirements
 
@@ -25,17 +25,17 @@ Recommended: use npx so you always run the latest published version from npm.
 Option A — Claude Code CLI
 
 ```bash
-claude mcp add firefox-devtools npx firefox-devtools-mcp@latest
+claude mcp add firewatch npx firewatch-mcp@latest
 ```
 
 Pass options either as args or env vars. Examples:
 
 ```bash
 # Headless + viewport via args
-claude mcp add firefox-devtools npx firefox-devtools-mcp@latest -- --headless --viewport 1280x720
+claude mcp add firewatch npx firewatch-mcp@latest -- --headless --viewport 1280x720
 
 # Or via environment variables
-claude mcp add firefox-devtools npx firefox-devtools-mcp@latest \
+claude mcp add firewatch npx firewatch-mcp@latest \
   --env START_URL=https://example.com \
   --env FIREFOX_HEADLESS=true
 ```
@@ -51,9 +51,9 @@ Add to your Claude Code config file:
 ```json
 {
   "mcpServers": {
-    "firefox-devtools": {
+    "firewatch": {
       "command": "npx",
-      "args": ["-y", "firefox-devtools-mcp@latest", "--headless", "--viewport", "1280x720"],
+      "args": ["-y", "firewatch-mcp@latest", "--headless", "--viewport", "1280x720"],
       "env": {
         "START_URL": "about:home"
       }
@@ -72,7 +72,7 @@ npm run setup
 ## Try it with MCP Inspector
 
 ```bash
-npx @modelcontextprotocol/inspector npx firefox-devtools-mcp@latest --start-url https://example.com --headless
+npx @modelcontextprotocol/inspector npx firewatch-mcp@latest --start-url https://example.com --headless
 ```
 
 Then call tools like:
@@ -111,7 +111,7 @@ Use `--connect-existing` to automate your real browsing session — with cookies
 firefox --marionette
 
 # Run the MCP server
-npx firefox-devtools-mcp --connect-existing --marionette-port 2828
+npx firewatch-mcp --connect-existing --marionette-port 2828
 ```
 
 Or set `marionette.enabled` to `true` in `about:config` (or `user.js`) to enable Marionette on every launch.
@@ -187,14 +187,14 @@ See [docs/testing.md](docs/testing.md) for full details on running specific test
 - Firefox not found: pass `--firefox-path "/Applications/Firefox.app/Contents/MacOS/firefox"` (macOS) or the correct path on your OS.
 - First run is slow: Selenium sets up the BiDi session; subsequent runs are faster.
 - Stale UIDs after navigation: take a fresh snapshot (`take_snapshot`) before using UID tools.
-- Windows 10: Error during discovery for MCP server 'firefox-devtools': MCP error -32000: Connection closed
+- Windows 10: Error during discovery for MCP server 'firewatch': MCP error -32000: Connection closed
   - **Solution 1** Call using `cmd` (For more info https://github.com/modelcontextprotocol/servers/issues/1082#issuecomment-2791786310)
 
     ```json
     "mcpServers": {
-      "firefox-devtools": {
+      "firewatch": {
         "command": "cmd",
-        "args": ["/c", "npx", "-y", "firefox-devtools-mcp@latest"]
+        "args": ["/c", "npx", "-y", "firewatch-mcp@latest"]
       }
     }
     ```
@@ -205,9 +205,9 @@ See [docs/testing.md](docs/testing.md) for full details on running specific test
 
     ```json
     "mcpServers": {
-      "firefox-devtools": {
+      "firewatch": {
         "command": "C:\\nvm4w\\nodejs\\npx.ps1",
-        "args": ["-y", "firefox-devtools-mcp@latest"]
+        "args": ["-y", "firewatch-mcp@latest"]
       }
     }
     ```
@@ -227,10 +227,10 @@ See [docs/testing.md](docs/testing.md) for full details on running specific test
 Issues are tracked on [Bugzilla](https://bugzilla.mozilla.org) under **product: Developer Infrastructure**, **component: AI for Development**.
 
 - [File a new issue](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&blocked=2026717&product=Developer%20Infrastructure&component=AI%20for%20Development)
-- [Meta bug (tracks all firefox-devtools-mcp issues)](https://bugzilla.mozilla.org/show_bug.cgi?id=2026717)
+- [Meta bug (tracks upstream firefox-devtools-mcp issues)](https://bugzilla.mozilla.org/show_bug.cgi?id=2026717)
 
-For questions and discussion, join the [#firefox-devtools-mcp Matrix room](https://chat.mozilla.org/#/room/#firefox-devtools-mcp:mozilla.org).
+For questions and discussion about the upstream project, join the [#firefox-devtools-mcp Matrix room](https://chat.mozilla.org/#/room/#firefox-devtools-mcp:mozilla.org).
 
 ## Author
 
-Maintained by [Mozilla](https://www.mozilla.org).
+Maintained by Jan Th Mueller as an independent fork of Mozilla's Firefox DevTools MCP.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Firewatch MCP
 
 [![npm version](https://badge.fury.io/js/firewatch-mcp.svg)](https://www.npmjs.com/package/firewatch-mcp)
-[![CI](https://github.com/janthmueller/firefox-devtools-mcp/workflows/CI/badge.svg)](https://github.com/janthmueller/firefox-devtools-mcp/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/janthmueller/firefox-devtools-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/janthmueller/firefox-devtools-mcp)
+[![CI](https://github.com/janthmueller/firewatch-mcp/workflows/CI/badge.svg)](https://github.com/janthmueller/firewatch-mcp/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/janthmueller/firewatch-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/janthmueller/firewatch-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 <a href="https://glama.ai/mcp/servers/firewatch-mcp"><img src="https://glama.ai/mcp/servers/firewatch-mcp/badge" height="223" alt="Glama"></a>
 
 Model Context Protocol server for automating Firefox via WebDriver BiDi (through Selenium WebDriver). Firewatch MCP works with Claude Code, Claude Desktop, Cursor, Cline and other MCP clients.
 
-Repository: https://github.com/janthmueller/firefox-devtools-mcp
+Repository: https://github.com/janthmueller/firewatch-mcp
+
+> **Independent fork:** Firewatch MCP is an independent fork of Mozilla's Firefox DevTools MCP. It is not an official Mozilla product and is published separately under the `firewatch-mcp` package name.
 
 > **Note**: This MCP server requires a local Firefox browser installation and cannot run on cloud hosting services like glama.ai. Use `npx firewatch-mcp@latest` to run locally, or use Docker with the provided Dockerfile.
 
@@ -224,12 +226,25 @@ See [docs/testing.md](docs/testing.md) for full details on running specific test
 
 ## Issues and Contributing
 
-Issues are tracked on [Bugzilla](https://bugzilla.mozilla.org) under **product: Developer Infrastructure**, **component: AI for Development**.
+Firewatch MCP issues are tracked in this repository:
 
-- [File a new issue](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&blocked=2026717&product=Developer%20Infrastructure&component=AI%20for%20Development)
+- [Open a Firewatch MCP issue](https://github.com/janthmueller/firewatch-mcp/issues)
+
+Upstream Firefox DevTools MCP issues are tracked on [Bugzilla](https://bugzilla.mozilla.org) under **product: Developer Infrastructure**, **component: AI for Development**.
+
+- [File a new upstream issue](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&blocked=2026717&product=Developer%20Infrastructure&component=AI%20for%20Development)
 - [Meta bug (tracks upstream firefox-devtools-mcp issues)](https://bugzilla.mozilla.org/show_bug.cgi?id=2026717)
 
 For questions and discussion about the upstream project, join the [#firefox-devtools-mcp Matrix room](https://chat.mozilla.org/#/room/#firefox-devtools-mcp:mozilla.org).
+
+## Upstream
+
+Firewatch MCP is derived from Mozilla's Firefox DevTools MCP:
+
+- Upstream repository: https://github.com/mozilla/firefox-devtools-mcp
+- Firewatch MCP repository: https://github.com/janthmueller/firewatch-mcp
+
+Some historical changelog entries, test fixtures, or issue references may still point to the upstream project where that context is part of the project history.
 
 ## Author
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.8'
 
 services:
-  firefox-devtools-mcp:
+  firewatch-mcp:
     build:
       context: .
       dockerfile: Dockerfile
-    image: firefox-devtools-mcp:latest
-    container_name: firefox-devtools-mcp
+    image: firewatch-mcp:latest
+    container_name: firewatch-mcp
     stdin_open: true
     tty: true
     environment:

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -13,10 +13,6 @@ Workflows
 - PR Check (.github/workflows/pr-check.yml)
   - Fast checks on PR open/update: lint, format check, typecheck.
 
-- Version Check (.github/workflows/version-check.yml)
-  - On tag push `v*`: compares the tag version with `package.json`.
-  - Fails if they differ (bump package.json before tagging).
-
 - Release (.github/workflows/release.yml)
   - On tag push `v*`: runs tests, builds `dist/`, creates a GitHub Release with a tarball of `dist` + metadata.
 
@@ -25,7 +21,7 @@ Workflows
   - Requires `NPM_TOKEN` repository secret.
 
 Secrets
-- `NPM_TOKEN`: npm access token with publish rights to the package name (`firefox-devtools-mcp`).
+- `NPM_TOKEN`: npm access token with publish rights to the package name (`firewatch-mcp`).
 - `CODECOV_TOKEN` (optional): used by Codecov upload step (CI). The step is skipped if the token or coverage file is missing.
 
 Release flow
@@ -34,12 +30,11 @@ Release flow
    - Commit the change
 2) Create and push the tag (must match package.json):
    - `git tag v0.2.0 && git push origin v0.2.0`
-3) The `version-check` job validates the tag vs. package.json.
-4) `release` creates a GitHub Release; `publish` publishes to npm.
+3) `release` creates a GitHub Release; `publish` publishes to npm.
 
 Windows Integration Tests
 - On Windows, vitest has known issues with process forking when running integration tests that spawn Firefox.
-- See: https://github.com/mozilla/firefox-devtools-mcp/issues/33
+- See: https://github.com/janthmueller/firefox-devtools-mcp/issues/33
 - To work around this, we use a separate test runner (`scripts/run-integration-tests-windows.mjs`) that runs integration tests directly via Node.js without vitest's process isolation.
 - The CI workflow detects Windows and automatically uses this runner instead of vitest for integration tests.
 - Unit tests still run via vitest on all platforms.
@@ -48,4 +43,3 @@ Notes
 - If you want Codecov upload to run, switch CI test step to `npm run test:coverage` or generate `coverage/lcov.info`.
 - Provenance is enabled for npm publish (Node 20+).
 - Use `@latest` in README examples to encourage npx usage.
-

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -3,7 +3,9 @@
 This project ships with ready-to-use GitHub Actions for CI, release, and npm publishing.
 
 Workflows
+
 - CI (.github/workflows/ci.yml)
+
   - Triggers on push to `main` and `develop`.
   - Matrix: Node 20 and 22.
   - Steps: install → lint → format check → typecheck → test → build.
@@ -11,9 +13,11 @@ Workflows
   - Uploads the `dist/` artifact (Node 20 job) for quick download.
 
 - PR Check (.github/workflows/pr-check.yml)
+
   - Fast checks on PR open/update: lint, format check, typecheck, unit tests, build.
 
 - Release (.github/workflows/release.yml)
+
   - On tag push `v*`: runs tests, builds `dist/`, creates a GitHub Release with a tarball of `dist` + metadata.
 
 - Publish (.github/workflows/publish.yml)
@@ -21,25 +25,29 @@ Workflows
   - Uses npm trusted publishing via GitHub Actions OIDC; no `NPM_TOKEN` is required.
 
 Secrets
+
 - `CODECOV_TOKEN` (optional): used by Codecov upload step (CI). The step is skipped if the token or coverage file is missing.
 
 Release flow
-1) Bump version in `package.json` (keep 0.x until API is stable):
+
+1. Bump version in `package.json` (keep 0.x until API is stable):
    - `npm version patch` (or minor)
    - Commit the change
-2) Create and push the tag (must match package.json):
+2. Create and push the tag (must match package.json):
    - `git tag v0.2.0 && git push origin v0.2.0`
-3) `release` creates a GitHub Release; `publish` publishes to npm.
-4) For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
+3. `release` creates a GitHub Release; `publish` publishes to npm.
+4. For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
 
 Windows Integration Tests
+
 - On Windows, vitest has known issues with process forking when running integration tests that spawn Firefox.
-- See: https://github.com/janthmueller/firewatch-mcp/issues/33
+- See upstream: https://github.com/mozilla/firefox-devtools-mcp/issues/33
 - To work around this, we use a separate test runner (`scripts/run-integration-tests-windows.mjs`) that runs integration tests directly via Node.js without vitest's process isolation.
 - The CI workflow detects Windows and automatically uses this runner instead of vitest for integration tests.
 - Unit tests still run via vitest on all platforms.
 
 Notes
+
 - If you want Codecov upload to run, switch CI test step to `npm run test:coverage` or generate `coverage/lcov.info`.
 - Provenance is enabled for npm publish (Node 20+).
 - Trusted publishing requires GitHub-hosted runners plus npm trusted publisher configuration on the package settings page.

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -4,24 +4,23 @@ This project ships with ready-to-use GitHub Actions for CI, release, and npm pub
 
 Workflows
 - CI (.github/workflows/ci.yml)
-  - Triggers on push (main, develop) and PRs.
+  - Triggers on push to `main` and `develop`.
   - Matrix: Node 20 and 22.
   - Steps: install → lint → format check → typecheck → test → build.
   - Optional: uploads coverage to Codecov if `coverage/lcov.info` exists and `CODECOV_TOKEN` is set.
   - Uploads the `dist/` artifact (Node 20 job) for quick download.
 
 - PR Check (.github/workflows/pr-check.yml)
-  - Fast checks on PR open/update: lint, format check, typecheck.
+  - Fast checks on PR open/update: lint, format check, typecheck, unit tests, build.
 
 - Release (.github/workflows/release.yml)
   - On tag push `v*`: runs tests, builds `dist/`, creates a GitHub Release with a tarball of `dist` + metadata.
 
 - Publish (.github/workflows/publish.yml)
-  - On GitHub Release published or on tag push `v*.*.*` (and via manual dispatch): builds and publishes to npm with provenance.
-  - Requires `NPM_TOKEN` repository secret.
+  - On tag push `v*.*.*` (and via manual dispatch): builds and publishes to npm with provenance.
+  - Uses npm trusted publishing via GitHub Actions OIDC; no `NPM_TOKEN` is required.
 
 Secrets
-- `NPM_TOKEN`: npm access token with publish rights to the package name (`firewatch-mcp`).
 - `CODECOV_TOKEN` (optional): used by Codecov upload step (CI). The step is skipped if the token or coverage file is missing.
 
 Release flow
@@ -31,6 +30,7 @@ Release flow
 2) Create and push the tag (must match package.json):
    - `git tag v0.2.0 && git push origin v0.2.0`
 3) `release` creates a GitHub Release; `publish` publishes to npm.
+4) For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
 
 Windows Integration Tests
 - On Windows, vitest has known issues with process forking when running integration tests that spawn Firefox.
@@ -42,4 +42,5 @@ Windows Integration Tests
 Notes
 - If you want Codecov upload to run, switch CI test step to `npm run test:coverage` or generate `coverage/lcov.info`.
 - Provenance is enabled for npm publish (Node 20+).
+- Trusted publishing requires GitHub-hosted runners plus npm trusted publisher configuration on the package settings page.
 - Use `@latest` in README examples to encourage npx usage.

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -34,7 +34,7 @@ Release flow
 
 Windows Integration Tests
 - On Windows, vitest has known issues with process forking when running integration tests that spawn Firefox.
-- See: https://github.com/janthmueller/firefox-devtools-mcp/issues/33
+- See: https://github.com/janthmueller/firewatch-mcp/issues/33
 - To work around this, we use a separate test runner (`scripts/run-integration-tests-windows.mjs`) that runs integration tests directly via Node.js without vitest's process isolation.
 - The CI workflow detects Windows and automatically uses this runner instead of vitest for integration tests.
 - Unit tests still run via vitest on all platforms.

--- a/docs/firefox-client.md
+++ b/docs/firefox-client.md
@@ -173,7 +173,7 @@ When Firefox runs in WebDriver BiDi mode (automated testing), it applies [Recomm
 At startup via CLI:
 ```bash
 # Enable ML/AI features like Smart Window
-npx firefox-devtools-mcp --pref "browser.ml.enable=true"
+npx firewatch-mcp --pref "browser.ml.enable=true"
 ```
 
 At runtime via tools (requires `MOZ_REMOTE_ALLOW_SYSTEM_ACCESS=1`):
@@ -349,7 +349,7 @@ firefox.clearNetworkRequests();
 npm run build
 
 # Test BiDi implementation
-DEBUG=firefox-devtools npm run test:tools
+DEBUG=firewatch npm run test:tools
 
 # Test script with comprehensive checks
 node scripts/test-bidi-devtools.js
@@ -357,10 +357,10 @@ node scripts/test-bidi-devtools.js
 
 ### Debug Logging
 
-Set `DEBUG=firefox-devtools` environment variable for verbose logging:
+Set `DEBUG=firewatch` environment variable for verbose logging:
 
 ```bash
-DEBUG=firefox-devtools node scripts/test-bidi-devtools.js
+DEBUG=firewatch node scripts/test-bidi-devtools.js
 ```
 
 Logs include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "firefox-devtools-mcp",
+  "name": "firewatch-mcp",
   "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "firefox-devtools-mcp",
+      "name": "firewatch-mcp",
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
         "yargs": "17.7.2"
       },
       "bin": {
-        "firefox-devtools-mcp": "dist/index.js"
+        "firewatch-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/jsdom": "28.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "firefox-devtools-mcp",
+  "name": "firewatch-mcp",
   "version": "0.9.1",
-  "description": "Model Context Protocol (MCP) server for Firefox DevTools automation",
-  "author": "Mozilla",
+  "description": "Model Context Protocol (MCP) server for Firefox browser automation",
+  "author": "Jan Th Mueller",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "firefox-devtools-mcp": "./dist/index.js"
+    "firewatch-mcp": "./dist/index.js"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
@@ -43,7 +43,7 @@
     "mcp-server",
     "model-context-protocol",
     "firefox",
-    "firefox-devtools",
+    "firewatch",
     "browser-automation",
     "webdriver-bidi",
     "selenium",
@@ -95,12 +95,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla/firefox-devtools-mcp.git"
+    "url": "git+https://github.com/janthmueller/firefox-devtools-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/mozilla/firefox-devtools-mcp/issues"
+    "url": "https://github.com/janthmueller/firefox-devtools-mcp/issues"
   },
-  "homepage": "https://github.com/mozilla/firefox-devtools-mcp#readme",
+  "homepage": "https://github.com/janthmueller/firefox-devtools-mcp#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "firewatch-mcp",
   "version": "0.9.1",
-  "description": "Model Context Protocol (MCP) server for Firefox browser automation",
+  "description": "Independent fork of Firefox DevTools MCP for Firefox browser automation",
   "author": "Jan Th Mueller",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "firewatch-mcp": "./dist/index.js"
+    "firewatch-mcp": "dist/index.js"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
@@ -95,12 +95,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/janthmueller/firefox-devtools-mcp.git"
+    "url": "git+https://github.com/janthmueller/firewatch-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/janthmueller/firefox-devtools-mcp/issues"
+    "url": "https://github.com/janthmueller/firewatch-mcp/issues"
   },
-  "homepage": "https://github.com/janthmueller/firefox-devtools-mcp#readme",
+  "homepage": "https://github.com/janthmueller/firewatch-mcp#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/plugins/claude/firefox-devtools/.mcp.json
+++ b/plugins/claude/firefox-devtools/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "firefox-devtools": {
-      "command": "npx",
-      "args": ["-y", "firefox-devtools-mcp@latest"]
-    }
-  }
-}

--- a/plugins/claude/firewatch/.claude-plugin/plugin.json
+++ b/plugins/claude/firewatch/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "firefox-devtools",
+  "name": "firewatch",
   "description": "Firefox browser automation via WebDriver BiDi. Automate Firefox for testing, scraping, form filling, screenshots, and debugging.",
   "version": "0.6.0",
   "author": {
-    "name": "Mozilla",
-    "url": "https://github.com/mozilla/firefox-devtools-mcp"
+    "name": "Jan Th Mueller",
+    "url": "https://github.com/janthmueller/firefox-devtools-mcp"
   },
-  "repository": "https://github.com/mozilla/firefox-devtools-mcp",
+  "repository": "https://github.com/janthmueller/firefox-devtools-mcp",
   "license": "MIT"
 }

--- a/plugins/claude/firewatch/.claude-plugin/plugin.json
+++ b/plugins/claude/firewatch/.claude-plugin/plugin.json
@@ -4,8 +4,8 @@
   "version": "0.6.0",
   "author": {
     "name": "Jan Th Mueller",
-    "url": "https://github.com/janthmueller/firefox-devtools-mcp"
+    "url": "https://github.com/janthmueller/firewatch-mcp"
   },
-  "repository": "https://github.com/janthmueller/firefox-devtools-mcp",
+  "repository": "https://github.com/janthmueller/firewatch-mcp",
   "license": "MIT"
 }

--- a/plugins/claude/firewatch/.mcp.json
+++ b/plugins/claude/firewatch/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "firewatch": {
+      "command": "npx",
+      "args": ["-y", "firewatch-mcp@latest"]
+    }
+  }
+}

--- a/plugins/claude/firewatch/README.md
+++ b/plugins/claude/firewatch/README.md
@@ -1,4 +1,4 @@
-# Firefox DevTools Plugin for Claude Code
+# Firewatch Plugin for Claude Code
 
 Firefox browser automation via WebDriver BiDi. Navigate pages, fill forms, click elements, take screenshots, and monitor console/network activity.
 
@@ -9,42 +9,42 @@ This plugin provides:
 - **MCP Server** - Connects Claude Code to Firefox automation
 - **Skills** - Auto-triggers for browser automation, testing, and scraping tasks
 - **Agents** - Dedicated `e2e-tester` and `web-scraper` agents for focused tasks
-- **Commands** - `/firefox:navigate`, `/firefox:screenshot`, `/firefox:debug`
+- **Commands** - `/firewatch:navigate`, `/firewatch:screenshot`, `/firewatch:debug`
 
 ## Installation
 
 ```bash
-claude plugin install firefox-devtools
+claude plugin install firewatch
 ```
 
 ## Commands
 
-### /firefox:navigate
+### /firewatch:navigate
 
 Navigate to a URL and take a DOM snapshot:
 
 ```
-/firefox:navigate https://example.com
-/firefox:navigate https://github.com/login
+/firewatch:navigate https://example.com
+/firewatch:navigate https://github.com/login
 ```
 
-### /firefox:screenshot
+### /firewatch:screenshot
 
 Capture the current page or a specific element:
 
 ```
-/firefox:screenshot
-/firefox:screenshot e15
+/firewatch:screenshot
+/firewatch:screenshot e15
 ```
 
-### /firefox:debug
+### /firewatch:debug
 
 Show console errors and failed network requests:
 
 ```
-/firefox:debug
-/firefox:debug console
-/firefox:debug network
+/firewatch:debug
+/firewatch:debug console
+/firewatch:debug network
 ```
 
 ## Agents
@@ -78,5 +78,5 @@ The plugin works automatically when you ask about browser tasks:
 
 ## Links
 
-- [Repository](https://github.com/mozilla/firefox-devtools-mcp)
-- [npm](https://www.npmjs.com/package/firefox-devtools-mcp)
+- [Repository](https://github.com/janthmueller/firefox-devtools-mcp)
+- [npm](https://www.npmjs.com/package/firewatch-mcp)

--- a/plugins/claude/firewatch/README.md
+++ b/plugins/claude/firewatch/README.md
@@ -2,6 +2,8 @@
 
 Firefox browser automation via WebDriver BiDi. Navigate pages, fill forms, click elements, take screenshots, and monitor console/network activity.
 
+This plugin is part of Firewatch MCP, an independent fork of Mozilla's Firefox DevTools MCP.
+
 ## What's Included
 
 This plugin provides:
@@ -78,5 +80,6 @@ The plugin works automatically when you ask about browser tasks:
 
 ## Links
 
-- [Repository](https://github.com/janthmueller/firefox-devtools-mcp)
+- [Repository](https://github.com/janthmueller/firewatch-mcp)
 - [npm](https://www.npmjs.com/package/firewatch-mcp)
+- [Upstream](https://github.com/mozilla/firefox-devtools-mcp)

--- a/plugins/claude/firewatch/agents/e2e-tester.md
+++ b/plugins/claude/firewatch/agents/e2e-tester.md
@@ -4,7 +4,7 @@ description: Agent for running E2E tests on web applications. Navigates pages, f
 model: sonnet
 ---
 
-You are an E2E testing agent specializing in automated browser testing using Firefox DevTools MCP.
+You are an E2E testing agent specializing in automated browser testing using Firewatch MCP.
 
 ## Your Task
 

--- a/plugins/claude/firewatch/agents/web-scraper.md
+++ b/plugins/claude/firewatch/agents/web-scraper.md
@@ -4,7 +4,7 @@ description: Agent for extracting structured data from web pages. Navigates, han
 model: sonnet
 ---
 
-You are a web scraping agent specializing in data extraction using Firefox DevTools MCP.
+You are a web scraping agent specializing in data extraction using Firewatch MCP.
 
 ## Your Task
 

--- a/plugins/claude/firewatch/commands/debug.md
+++ b/plugins/claude/firewatch/commands/debug.md
@@ -3,24 +3,24 @@ description: Show console errors and failed network requests
 argument-hint: [console|network|all]
 ---
 
-# /firefox:debug
+# /firewatch:debug
 
 Displays debugging information from the current page.
 
 ## Usage
 
 ```
-/firefox:debug              # Show all (console errors + failed requests)
-/firefox:debug console      # Console messages only
-/firefox:debug network      # Network requests only
+/firewatch:debug              # Show all (console errors + failed requests)
+/firewatch:debug console      # Console messages only
+/firewatch:debug network      # Network requests only
 ```
 
 ## Examples
 
 ```
-/firefox:debug
-/firefox:debug console
-/firefox:debug network
+/firewatch:debug
+/firewatch:debug console
+/firewatch:debug network
 ```
 
 ## What Happens

--- a/plugins/claude/firewatch/commands/navigate.md
+++ b/plugins/claude/firewatch/commands/navigate.md
@@ -3,22 +3,22 @@ description: Navigate Firefox to a URL and take a snapshot
 argument-hint: <url>
 ---
 
-# /firefox:navigate
+# /firewatch:navigate
 
 Opens a URL in Firefox and takes a DOM snapshot for interaction.
 
 ## Usage
 
 ```
-/firefox:navigate <url>
+/firewatch:navigate <url>
 ```
 
 ## Examples
 
 ```
-/firefox:navigate https://example.com
-/firefox:navigate https://github.com/login
-/firefox:navigate file:///path/to/local.html
+/firewatch:navigate https://example.com
+/firewatch:navigate https://github.com/login
+/firewatch:navigate file:///path/to/local.html
 ```
 
 ## What Happens

--- a/plugins/claude/firewatch/commands/screenshot.md
+++ b/plugins/claude/firewatch/commands/screenshot.md
@@ -3,23 +3,23 @@ description: Take a screenshot of the current page or element
 argument-hint: [uid]
 ---
 
-# /firefox:screenshot
+# /firewatch:screenshot
 
 Captures a screenshot of the page or a specific element.
 
 ## Usage
 
 ```
-/firefox:screenshot          # Full page
-/firefox:screenshot <uid>    # Specific element
+/firewatch:screenshot          # Full page
+/firewatch:screenshot <uid>    # Specific element
 ```
 
 ## Examples
 
 ```
-/firefox:screenshot
-/firefox:screenshot e15
-/firefox:screenshot e42
+/firewatch:screenshot
+/firewatch:screenshot e15
+/firewatch:screenshot e42
 ```
 
 ## What Happens

--- a/plugins/claude/firewatch/skills/browser-automation/SKILL.md
+++ b/plugins/claude/firewatch/skills/browser-automation/SKILL.md
@@ -3,7 +3,7 @@ name: browser-automation
 description: This skill should be used when the user asks about browser automation, testing web pages, scraping content, filling forms, taking screenshots, or monitoring console/network activity. Activates for E2E testing, web scraping, form automation, or debugging web applications.
 ---
 
-When the user asks about browser automation, use Firefox DevTools MCP to control a real Firefox browser.
+When the user asks about browser automation, use Firewatch MCP to control a real Firefox browser.
 
 ## When to Use This Skill
 

--- a/scripts/demo-server.js
+++ b/scripts/demo-server.js
@@ -91,7 +91,7 @@ const HTML_PAGE = `
 </head>
 <body>
   <div class="container">
-    <h1>🦊 Firefox DevTools MCP</h1>
+    <h1>🔥 Firewatch MCP</h1>
     <p><strong>Demo Page for Testing MCP Tools</strong></p>
     <p>Use this page with the MCP Inspector to test various tools!</p>
 
@@ -204,7 +204,7 @@ const HTML_PAGE = `
 
     function logObject() {
       console.log('Object:', {
-        name: 'Firefox DevTools MCP',
+        name: 'Firewatch MCP',
         version: '0.1.0',
         features: ['console', 'dialog', 'input', 'screenshot'],
         config: { headless: false, timeout: 5000 }
@@ -263,7 +263,7 @@ const HTML_PAGE = `
     }
 
     // Initial log
-    console.log('🦊 Firefox DevTools MCP Demo Page Loaded!');
+    console.log('🔥 Firewatch MCP Demo Page Loaded!');
     console.info('Server running on http://localhost:3456');
     console.info('Use MCP Inspector to test tools: list_console_messages, list_pages, etc.');
   </script>
@@ -286,7 +286,7 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, () => {
   console.log('');
-  console.log('🦊 Firefox DevTools MCP - Demo Server');
+  console.log('🔥 Firewatch MCP - Demo Server');
   console.log('=====================================');
   console.log('');
   console.log(`🌐 Server running at: http://localhost:${PORT}`);

--- a/scripts/run-integration-tests-windows.mjs
+++ b/scripts/run-integration-tests-windows.mjs
@@ -3,7 +3,7 @@
  * Windows Integration Tests Runner
  *
  * Runs integration tests directly via node to avoid vitest fork issues on Windows.
- * See: https://github.com/mozilla/firefox-devtools-mcp/issues/33
+ * See: https://github.com/janthmueller/firefox-devtools-mcp/issues/33
  */
 
 import { FirefoxDevTools } from '../dist/index.js';

--- a/scripts/run-integration-tests-windows.mjs
+++ b/scripts/run-integration-tests-windows.mjs
@@ -3,7 +3,7 @@
  * Windows Integration Tests Runner
  *
  * Runs integration tests directly via node to avoid vitest fork issues on Windows.
- * See: https://github.com/janthmueller/firewatch-mcp/issues/33
+ * See upstream: https://github.com/mozilla/firefox-devtools-mcp/issues/33
  */
 
 import { FirefoxDevTools } from '../dist/index.js';

--- a/scripts/run-integration-tests-windows.mjs
+++ b/scripts/run-integration-tests-windows.mjs
@@ -3,7 +3,7 @@
  * Windows Integration Tests Runner
  *
  * Runs integration tests directly via node to avoid vitest fork issues on Windows.
- * See: https://github.com/janthmueller/firefox-devtools-mcp/issues/33
+ * See: https://github.com/janthmueller/firewatch-mcp/issues/33
  */
 
 import { FirefoxDevTools } from '../dist/index.js';

--- a/scripts/setup-mcp-config.js
+++ b/scripts/setup-mcp-config.js
@@ -62,7 +62,7 @@ function detectNodePath() {
 
 async function main() {
   console.log(
-    `${colors.bright}${colors.blue}🚀 Firefox DevTools MCP Configuration Setup${colors.reset}\n`
+    `${colors.bright}${colors.blue}🚀 Firewatch MCP Configuration Setup${colors.reset}\n`
   );
 
   // Ask which client to configure
@@ -136,7 +136,7 @@ async function main() {
   // Create MCP config
   const mcpConfig = {
     mcpServers: {
-      'firefox-devtools': {
+      firewatch: {
         command: finalNodePath,
         args: [distIndexPath, '--headless=' + (headless.toLowerCase() === 'y' ? 'true' : 'false'), '--viewport=' + viewport],
       },
@@ -192,9 +192,9 @@ async function main() {
     if (fs.existsSync(configPath)) {
       try {
         existingConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        if (existingConfig.mcpServers && existingConfig.mcpServers['firefox-devtools']) {
+        if (existingConfig.mcpServers && existingConfig.mcpServers.firewatch) {
           const overwrite = await question(
-            `\n${colors.yellow}⚠️  'firefox-devtools' server already exists in ${clientName}. Overwrite? (y/n): ${colors.reset}`
+            `\n${colors.yellow}⚠️  'firewatch' server already exists in ${clientName}. Overwrite? (y/n): ${colors.reset}`
           );
           if (overwrite.toLowerCase() !== 'y') {
             console.log(`Skipped ${clientName}`);

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@ pkgs.mkShell {
     export FIREFOX_BIN="${pkgs.firefox}/bin/firefox"
     export GECKODRIVER_BIN="${pkgs.geckodriver}/bin/geckodriver"
 
-    echo "firefox-devtools-mcp dev shell"
+    echo "firewatch-mcp dev shell"
     echo "Node: $(node --version)"
     echo "npm: $(npm --version)"
     echo "Firefox: $(${pkgs.firefox}/bin/firefox --version | head -n 1)"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ export const cliOptions = {
   firefoxArg: {
     type: 'array',
     description:
-      'Additional arguments for Firefox. Only applies when Firefox is launched by firefox-devtools-mcp.',
+      'Additional arguments for Firefox. Only applies when Firefox is launched by firewatch-mcp.',
   },
   startUrl: {
     type: 'string',
@@ -118,7 +118,7 @@ export const cliOptions = {
   outputFile: {
     type: 'string',
     description:
-      'Path to file where Firefox output (stdout/stderr) will be written. If not specified, output is written to ~/.firefox-devtools-mcp/output/',
+      'Path to file where Firefox output (stdout/stderr) will be written. If not specified, output is written to ~/.firewatch-mcp/output/',
   },
   pref: {
     type: 'array',
@@ -143,7 +143,7 @@ export const cliOptions = {
 
 export function parseArguments(version: string, argv = process.argv) {
   const yargsInstance = yargs(hideBin(argv))
-    .scriptName('npx firefox-devtools-mcp@latest')
+    .scriptName('npx firewatch-mcp@latest')
     .options(cliOptions)
     .example([
       [

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,6 @@
 /**
- * Configuration constants for Firefox DevTools MCP server
+ * Configuration constants for Firewatch MCP server
  */
 
-export const SERVER_NAME = 'firefox-devtools';
-export const SERVER_VERSION = '0.7.1';
+export const SERVER_NAME = 'firewatch';
+export const SERVER_VERSION = '0.9.1';

--- a/src/firefox/core.ts
+++ b/src/firefox/core.ts
@@ -114,7 +114,7 @@ export class FirefoxCore {
       if (this.options.logFile) {
         this.logFilePath = this.options.logFile;
       } else if (this.options.env && Object.keys(this.options.env).length > 0) {
-        const outputDir = join(homedir(), '.firefox-devtools-mcp', 'output');
+        const outputDir = join(homedir(), '.firewatch-mcp', 'output');
         mkdirSync(outputDir, { recursive: true });
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         this.logFilePath = join(outputDir, `firefox-${timestamp}.log`);

--- a/src/firefox/dom.ts
+++ b/src/firefox/dom.ts
@@ -62,7 +62,9 @@ export class DomInteractions {
         throw new Error('uid parameter is required when scope="uid"');
       }
       if (!this.resolveUid) {
-        throw new Error('extractText: resolveUid callback not set. Ensure snapshot is initialized.');
+        throw new Error(
+          'extractText: resolveUid callback not set. Ensure snapshot is initialized.'
+        );
       }
       targetElement = await this.resolveUid(uid);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Firefox DevTools MCP Server
+ * Firewatch MCP Server
  * Model Context Protocol server for Firefox browser automation via WebDriver BiDi
  */
 
@@ -105,7 +105,7 @@ export async function getFirefox(): Promise<FirefoxDevTools> {
   }
 
   // No existing instance - create new connection
-  log('Initializing Firefox DevTools connection...');
+  log('Initializing Firewatch connection...');
 
   let options: FirefoxLaunchOptions;
 
@@ -367,7 +367,7 @@ async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  log('Firefox DevTools MCP server running on stdio');
+  log('Firewatch MCP server running on stdio');
   log('Ready to accept tool requests');
 
   // Clean up the Marionette session so Firefox accepts new connections.

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -1,5 +1,5 @@
 /**
- * Network monitoring tools for Firefox DevTools MCP
+ * Network monitoring tools for Firewatch MCP
  * Provides network request inspection capabilities
  */
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,5 @@
 /**
- * Common types shared across the Firefox DevTools MCP server
+ * Common types shared across the Firewatch MCP server
  */
 
 export type McpContentItem =

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Custom error classes for Firefox DevTools MCP
+ * Custom error classes for Firewatch MCP
  */
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,24 +1,24 @@
 /**
- * Simple logger for Firefox DevTools MCP server
+ * Simple logger for Firewatch MCP server
  */
 
 export function log(message: string, ...args: unknown[]): void {
-  console.error(`[firefox-devtools-mcp] ${message}`, ...args);
+  console.error(`[firewatch-mcp] ${message}`, ...args);
 }
 
 export function logError(message: string, error?: unknown): void {
   if (error instanceof Error) {
-    console.error(`[firefox-devtools-mcp] ERROR: ${message}`, error.message);
+    console.error(`[firewatch-mcp] ERROR: ${message}`, error.message);
     if (error.stack) {
       console.error(error.stack);
     }
   } else {
-    console.error(`[firefox-devtools-mcp] ERROR: ${message}`, error);
+    console.error(`[firewatch-mcp] ERROR: ${message}`, error);
   }
 }
 
 export function logDebug(message: string, ...args: unknown[]): void {
-  if (process.env.DEBUG === '*' || process.env.DEBUG?.includes('firefox-devtools')) {
-    console.error(`[firefox-devtools-mcp] DEBUG: ${message}`, ...args);
+  if (process.env.DEBUG === '*' || process.env.DEBUG?.includes('firewatch')) {
+    console.error(`[firewatch-mcp] DEBUG: ${message}`, ...args);
   }
 }

--- a/tests/config/constants.test.ts
+++ b/tests/config/constants.test.ts
@@ -12,8 +12,8 @@ describe('Constants', () => {
       expect(typeof SERVER_NAME).toBe('string');
     });
 
-    it('should be firefox-devtools', () => {
-      expect(SERVER_NAME).toBe('firefox-devtools');
+    it('should be firewatch', () => {
+      expect(SERVER_NAME).toBe('firewatch');
     });
   });
 
@@ -23,7 +23,7 @@ describe('Constants', () => {
     });
 
     it('should match package.json version', () => {
-      expect(SERVER_VERSION).toBe('0.7.1');
+      expect(SERVER_VERSION).toBe('0.9.1');
     });
 
     it('should be a non-empty string', () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,5 +1,5 @@
 /**
- * Smoke tests for firefox-devtools-mcp
+ * Smoke tests for firewatch-mcp
  *
  * These tests verify basic functionality without requiring a Firefox instance.
  * More comprehensive integration tests should be added as the project matures.
@@ -11,12 +11,12 @@ import { SERVER_NAME, SERVER_VERSION } from '../src/config/constants.js';
 describe('Smoke Tests', () => {
   describe('Constants', () => {
     it('should have correct server name', () => {
-      expect(SERVER_NAME).toBe('firefox-devtools');
+      expect(SERVER_NAME).toBe('firewatch');
     });
 
     it('should have valid server version', () => {
       expect(SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+/);
-      expect(SERVER_VERSION).toBe('0.7.1');
+      expect(SERVER_VERSION).toBe('0.9.1');
     });
   });
 

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -20,13 +20,13 @@ describe('Logger Utilities', () => {
   describe('log', () => {
     it('should log messages with prefix', () => {
       log('Test message');
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[firefox-devtools-mcp] Test message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] Test message');
     });
 
     it('should log messages with additional arguments', () => {
       log('Test message', 'arg1', 123);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firefox-devtools-mcp] Test message',
+        '[firewatch-mcp] Test message',
         'arg1',
         123
       );
@@ -39,7 +39,7 @@ describe('Logger Utilities', () => {
       logError('Something failed', error);
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firefox-devtools-mcp] ERROR: Something failed',
+        '[firewatch-mcp] ERROR: Something failed',
         'Test error'
       );
     });
@@ -58,7 +58,7 @@ describe('Logger Utilities', () => {
       logError('Something failed', { code: 500 });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firefox-devtools-mcp] ERROR: Something failed',
+        '[firewatch-mcp] ERROR: Something failed',
         { code: 500 }
       );
     });
@@ -67,7 +67,7 @@ describe('Logger Utilities', () => {
       logError('Something failed');
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firefox-devtools-mcp] ERROR: Something failed',
+        '[firewatch-mcp] ERROR: Something failed',
         undefined
       );
     });
@@ -83,24 +83,24 @@ describe('Logger Utilities', () => {
       process.env.DEBUG = '*';
       logDebug('Debug message');
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[firefox-devtools-mcp] DEBUG: Debug message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] DEBUG: Debug message');
     });
 
-    it('should log when DEBUG includes firefox-devtools', () => {
-      process.env.DEBUG = 'firefox-devtools';
+    it('should log when DEBUG includes firewatch', () => {
+      process.env.DEBUG = 'firewatch';
       logDebug('Debug message');
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[firefox-devtools-mcp] DEBUG: Debug message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] DEBUG: Debug message');
     });
 
-    it('should log when DEBUG includes firefox-devtools with other modules', () => {
-      process.env.DEBUG = 'app,firefox-devtools,other';
+    it('should log when DEBUG includes firewatch with other modules', () => {
+      process.env.DEBUG = 'app,firewatch,other';
       logDebug('Debug message');
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[firefox-devtools-mcp] DEBUG: Debug message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] DEBUG: Debug message');
     });
 
-    it('should not log when DEBUG does not include firefox-devtools', () => {
+    it('should not log when DEBUG does not include firewatch', () => {
       process.env.DEBUG = 'other-module';
       logDebug('Debug message');
 
@@ -112,7 +112,7 @@ describe('Logger Utilities', () => {
       logDebug('Debug message', 'arg1', 123);
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firefox-devtools-mcp] DEBUG: Debug message',
+        '[firewatch-mcp] DEBUG: Debug message',
         'arg1',
         123
       );

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -25,11 +25,7 @@ describe('Logger Utilities', () => {
 
     it('should log messages with additional arguments', () => {
       log('Test message', 'arg1', 123);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firewatch-mcp] Test message',
-        'arg1',
-        123
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] Test message', 'arg1', 123);
     });
   });
 
@@ -57,10 +53,9 @@ describe('Logger Utilities', () => {
     it('should log non-Error objects', () => {
       logError('Something failed', { code: 500 });
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[firewatch-mcp] ERROR: Something failed',
-        { code: 500 }
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[firewatch-mcp] ERROR: Something failed', {
+        code: 500,
+      });
     });
 
     it('should log without error object', () => {


### PR DESCRIPTION
## Summary
- rename the forked package, CLI, plugin, docs, and release artifacts to `firewatch-mcp`
- clarify fork identity, support routing, and upstream relationship in public-facing docs
- switch npm publishing to trusted publishing via GitHub Actions OIDC and remove duplicate publish triggers

## Verification
- `nix-shell --run 'npm run typecheck'`
- `nix-shell --run 'npm run build'`
- `nix-shell --run 'npm run test:unit'`
- `nix-shell --run 'npm run test:run -- tests/integration/text-extraction.integration.test.ts'`
- `npm publish --access public` (initial manual publish of `firewatch-mcp@0.9.1`)

Closes #7