### PR TITLE
fix: restore packaged firewatch startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify packaged artifact startup
+        run: npm run test:package-artifact
+
       - name: Install Firefox
         uses: browser-actions/setup-firefox@latest
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Verify packaged artifact startup
+        run: npm run test:package-artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -44,6 +43,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Verify packaged artifact startup
+        run: npm run test:package-artifact
 
       - name: Install Firefox
         uses: browser-actions/setup-firefox@latest

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -8,16 +8,16 @@ Workflows
 
   - Triggers on push to `main` and `develop`.
   - Matrix: Node 20 and 22.
-  - Steps: install → lint → format check → typecheck → test → build.
+  - Steps: install → lint → format check → typecheck → build → packaged-artifact smoke test → Firefox test suite.
   - Optional: uploads coverage to Codecov if `coverage/lcov.info` exists and `CODECOV_TOKEN` is set.
   - Uploads the `dist/` artifact (Node 20 job) for quick download.
 
 - PR Check (.github/workflows/pr-check.yml)
 
-  - Fast checks on PR open/update: lint, format check, typecheck, unit tests, build.
+  - Fast checks on PR open/update: lint, format check, typecheck, unit tests, build, packaged-artifact smoke test.
 
 - Release (.github/workflows/publish.yml)
-  - On push to `main` (and via manual dispatch): runs checks, then executes `semantic-release`.
+  - On push to `main` (and via manual dispatch): runs checks, verifies the packaged CLI startup path, then executes `semantic-release`.
   - `semantic-release` analyzes conventional commits, updates `CHANGELOG.md`, creates the next version tag, publishes `firewatch-mcp` to npm with provenance, and creates a GitHub Release with the npm tarball attached.
 
 Secrets
@@ -34,6 +34,7 @@ Release flow
    - `!` or `BREAKING CHANGE:` -> major
 4. If a release is needed, `semantic-release` updates `CHANGELOG.md`, creates the release commit and git tag, publishes `firewatch-mcp` to npm via trusted publishing, and creates the GitHub Release.
 5. For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
+6. The workflow checkout must keep GitHub credentials available so the semantic-release git plugin can push the release commit back to `main`.
 
 Conventional commit examples
 
@@ -56,4 +57,5 @@ Notes
 - Provenance is enabled for npm publish via trusted publishing on GitHub-hosted runners.
 - Conventional commit messages on `main` now drive versioning and release notes.
 - `CHANGELOG.md` is maintained automatically by semantic-release and committed back to `main` during releases.
+- A packaged-artifact smoke test (`npm pack` + `node dist/index.js --version`) runs in PR, CI, and release workflows to catch bundle-only startup regressions before publish.
 - Use `@latest` in README examples to encourage npx usage.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",
     "test:ui": "vitest --ui",
+    "test:package-artifact": "node scripts/verify-package-artifact.mjs",
     "test:tools": "node scripts/test-bidi-devtools.js",
     "test:input": "node scripts/test-input-tools.js",
     "test:screenshot": "node scripts/test-screenshot.js",

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function main() {
+  const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+  const tempDirectory = mkdtempSync(join(tmpdir(), 'firewatch-pack-'));
+  let tarballPath = '';
+
+  try {
+    const packOutput = execFileSync('npm', ['pack', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const packResult = JSON.parse(packOutput);
+    const tarballName = packResult[0]?.filename;
+
+    if (typeof tarballName !== 'string' || tarballName.length === 0) {
+      throw new Error('npm pack did not return a tarball filename');
+    }
+
+    tarballPath = join(repoRoot, tarballName);
+    execFileSync('tar', ['-xzf', tarballPath, '-C', tempDirectory], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+
+    const packageDirectory = join(tempDirectory, 'package');
+    execFileSync('npm', ['install', '--omit=dev', '--ignore-scripts'], {
+      cwd: packageDirectory,
+      stdio: 'inherit',
+    });
+
+    const packagedEntrypoint = join(packageDirectory, 'dist', 'index.js');
+    const versionOutput = execFileSync('node', [packagedEntrypoint, '--version'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+
+    const packageVersion = packResult[0]?.version;
+    if (versionOutput !== packageVersion) {
+      throw new Error(
+        `Packaged CLI reported version "${versionOutput}" instead of "${packageVersion}"`
+      );
+    }
+  } finally {
+    if (tarballPath.length > 0) {
+      rmSync(tarballPath, { force: true });
+    }
+    rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,16 +2,43 @@
  * Configuration constants for Firewatch MCP server
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const SERVER_NAME = 'firewatch';
+const PACKAGE_NAME = 'firewatch-mcp';
 
 type PackageMetadata = {
+  name: string;
   version: string;
 };
 
-const packageMetadata = JSON.parse(
-  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
-) as PackageMetadata;
+function readPackageMetadata(): PackageMetadata {
+  let currentDirectory: string = dirname(fileURLToPath(import.meta.url));
+
+  while (currentDirectory.length > 0) {
+    const packageJsonPath: string = resolve(currentDirectory, 'package.json');
+
+    if (existsSync(packageJsonPath)) {
+      const packageMetadata = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageMetadata;
+
+      if (packageMetadata.name === PACKAGE_NAME && packageMetadata.version.length > 0) {
+        return packageMetadata;
+      }
+    }
+
+    const parentDirectory: string = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error(`Could not locate package.json for ${PACKAGE_NAME}`);
+    }
+
+    currentDirectory = parentDirectory;
+  }
+
+  throw new Error(`Could not locate package.json for ${PACKAGE_NAME}`);
+}
+
+const packageMetadata = readPackageMetadata();
 
 export const SERVER_VERSION = packageMetadata.version;


### PR DESCRIPTION
## Summary
- fix bundled package version lookup so `npx firewatch-mcp@latest` starts correctly
- add a packaged-artifact smoke test that runs `npm pack`, installs production deps, and executes the built CLI
- keep semantic-release checkout credentials so release commits can be pushed back to `main`

## Testing
- `npm run build`
- `npm run test:unit`
- `npm run lint`
- `npm run format:check`
- `npm run test:package-artifact`

Closes #14