### PR TITLE
ci: trigger release after successful main ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,25 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   release:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,6 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -47,15 +57,10 @@ jobs:
       - name: Verify packaged artifact startup
         run: npm run test:package-artifact
 
-      - name: Install Firefox
-        uses: browser-actions/setup-firefox@latest
-        with:
-          firefox-version: latest
-
-      - name: Test
-        run: npm run test:run
-
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: refs/heads/main
+          GITHUB_REF_NAME: main
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: npm run release

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -17,7 +17,7 @@ Workflows
   - Fast checks on PR open/update: lint, format check, typecheck, unit tests, build, packaged-artifact smoke test.
 
 - Release (.github/workflows/publish.yml)
-  - On push to `main` (and via manual dispatch): runs checks, verifies the packaged CLI startup path, then executes `semantic-release`.
+  - On successful `CI` completion for `main` (and via manual dispatch): re-checks build/package integrity, then executes `semantic-release`.
   - `semantic-release` analyzes conventional commits, updates `CHANGELOG.md`, creates the next version tag, publishes `firewatch-mcp` to npm with provenance, and creates a GitHub Release with the npm tarball attached.
 
 Secrets
@@ -27,14 +27,15 @@ Secrets
 Release flow
 
 1. Merge conventional commits to `main`.
-2. The `publish` workflow runs `semantic-release` after checks pass.
-3. `semantic-release` determines the next semantic version from commit messages:
+2. The `CI` workflow runs the full Firefox/integration suite on the merge commit.
+3. If `CI` succeeds on `main`, the `publish` workflow runs `semantic-release`.
+4. `semantic-release` determines the next semantic version from commit messages:
    - `fix:` -> patch
    - `feat:` -> minor
    - `!` or `BREAKING CHANGE:` -> major
-4. If a release is needed, `semantic-release` updates `CHANGELOG.md`, creates the release commit and git tag, publishes `firewatch-mcp` to npm via trusted publishing, and creates the GitHub Release.
-5. For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
-6. The workflow checkout must keep GitHub credentials available so the semantic-release git plugin can push the release commit back to `main`.
+5. If a release is needed, `semantic-release` updates `CHANGELOG.md`, creates the release commit and git tag, publishes `firewatch-mcp` to npm via trusted publishing, and creates the GitHub Release.
+6. For npm publishing to work, the `firewatch-mcp` package on npm must trust the GitHub Actions workflow `publish.yml` for the `janthmueller/firewatch-mcp` repository.
+7. The workflow checkout must keep GitHub credentials available so the semantic-release git plugin can push the release commit back to `main`.
 
 Conventional commit examples
 
@@ -58,4 +59,5 @@ Notes
 - Conventional commit messages on `main` now drive versioning and release notes.
 - `CHANGELOG.md` is maintained automatically by semantic-release and committed back to `main` during releases.
 - A packaged-artifact smoke test (`npm pack` + `node dist/index.js --version`) runs in PR, CI, and release workflows to catch bundle-only startup regressions before publish.
+- Release now depends on a successful `CI` run for the same `main` commit instead of running the full Firefox suite itself.
 - Use `@latest` in README examples to encourage npx usage.


### PR DESCRIPTION
## Summary
- trigger the release workflow from successful `CI` runs on `main` instead of directly on every push
- keep release focused on build/package verification plus `semantic-release`
- update the release docs to reflect the new CI -> release flow

## Notes
- full Firefox/integration coverage remains in `CI`
- release no longer runs the full Firefox suite itself
- this restores a cleaner PR / CI / release split and avoids making release the first place integration failures surface

Closes #13