### PR TITLE
feat: add snapshot text truncation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Then call tools like:
 - `list_pages`, `select_page`, `navigate_page`
 - `extract_text` for rendered or DOM text from the page or a scoped region
 - `take_snapshot` then `click_by_uid` / `fill_by_uid`
+  - use `collectorMaxTextLength` and `formatterMaxTextLength` to control per-node text truncation
+  - omit the values for default compact previews, set them to `null` for uncapped node text
 - `list_network_requests` (always‑on capture), `get_network_request`
 - `screenshot_page`, `list_console_messages`
 

--- a/src/firefox/snapshot/formatter.ts
+++ b/src/firefox/snapshot/formatter.ts
@@ -8,7 +8,7 @@ import type { SnapshotNode } from './types.js';
 /**
  * Max attribute value length (aggressive truncation for token efficiency)
  */
-const MAX_ATTR_LENGTH = 30;
+const DEFAULT_MAX_TEXT_LENGTH = 30;
 
 /**
  * Formatting options
@@ -17,6 +17,7 @@ export interface FormatOptions {
   includeAttributes?: boolean;
   includeText?: boolean;
   maxDepth?: number;
+  maxTextLength?: number | null;
 }
 
 /**
@@ -27,7 +28,7 @@ export function formatSnapshotTree(
   depth = 0,
   options: FormatOptions = {}
 ): string {
-  const { includeAttributes = true, includeText = true, maxDepth } = options;
+  const { includeAttributes = true, includeText = true, maxDepth, maxTextLength } = options;
 
   // Check max depth
   if (maxDepth !== undefined && depth >= maxDepth) {
@@ -45,7 +46,7 @@ export function formatSnapshotTree(
 
   // Name (in quotes) - only if exists
   if (node.name) {
-    attrs.push(`"${truncate(node.name, MAX_ATTR_LENGTH)}"`);
+    attrs.push(`"${truncate(node.name, maxTextLength)}"`);
   }
 
   // Tag (for debugging)
@@ -55,22 +56,22 @@ export function formatSnapshotTree(
 
   // Value
   if (node.value) {
-    attrs.push(`value="${truncate(node.value, MAX_ATTR_LENGTH)}"`);
+    attrs.push(`value="${truncate(node.value, maxTextLength)}"`);
   }
 
   // Href
   if (node.href) {
-    attrs.push(`href="${truncate(node.href, MAX_ATTR_LENGTH)}"`);
+    attrs.push(`href="${truncate(node.href, maxTextLength)}"`);
   }
 
   // Src
   if (node.src) {
-    attrs.push(`src="${truncate(node.src, MAX_ATTR_LENGTH)}"`);
+    attrs.push(`src="${truncate(node.src, maxTextLength)}"`);
   }
 
   // Text (controlled by includeText option)
   if (includeText && node.text) {
-    attrs.push(`text="${truncate(node.text, MAX_ATTR_LENGTH)}"`);
+    attrs.push(`text="${truncate(node.text, maxTextLength)}"`);
   }
 
   // ARIA attributes (controlled by includeAttributes option)
@@ -141,7 +142,7 @@ export function formatSnapshotTree(
   if (node.isIframe) {
     attrs.push('[iframe');
     if (node.frameSrc) {
-      attrs.push(`src="${truncate(node.frameSrc, MAX_ATTR_LENGTH)}"`);
+      attrs.push(`src="${truncate(node.frameSrc, maxTextLength)}"`);
     }
     if (node.crossOrigin) {
       attrs.push('cross-origin');
@@ -162,9 +163,17 @@ export function formatSnapshotTree(
 /**
  * Truncate string to max length
  */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) {
+function truncate(str: string, maxLen: number | null | undefined): string {
+  if (maxLen === null) {
     return str;
   }
-  return str.substring(0, maxLen - 3) + '...';
+  const effectiveMaxLength = maxLen ?? DEFAULT_MAX_TEXT_LENGTH;
+
+  if (effectiveMaxLength <= 0) {
+    throw new Error('maxTextLength must be positive or null');
+  }
+  if (str.length <= effectiveMaxLength) {
+    return str;
+  }
+  return str.substring(0, effectiveMaxLength - 3) + '...';
 }

--- a/src/firefox/snapshot/injected/attributeCollector.ts
+++ b/src/firefox/snapshot/injected/attributeCollector.ts
@@ -8,13 +8,13 @@ import { isFocusable, isInteractive } from './elementCollector.js';
 /**
  * Max text length
  */
-const MAX_TEXT_LENGTH = 100;
+const DEFAULT_MAX_TEXT_LENGTH = 100;
 
 /**
  * Get element name/label
  * Checks aria-label, associated label, placeholder, title, alt
  */
-export function getElementName(el: Element): string | undefined {
+export function getElementName(el: Element, maxTextLength?: number | null): string | undefined {
   // aria-label
   if (el.hasAttribute('aria-label')) {
     return el.getAttribute('aria-label') || undefined;
@@ -48,7 +48,7 @@ export function getElementName(el: Element): string | undefined {
   // text content for buttons/links/headings
   const tag = el.tagName.toLowerCase();
   if (['button', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].indexOf(tag) !== -1) {
-    return getTextContent(el);
+    return getTextContent(el, maxTextLength);
   }
 
   return undefined;
@@ -57,7 +57,7 @@ export function getElementName(el: Element): string | undefined {
 /**
  * Get direct text content (not from deep children)
  */
-export function getTextContent(el: Element): string | undefined {
+export function getTextContent(el: Element, maxTextLength?: number | null): string | undefined {
   let text = '';
   for (let i = 0; i < el.childNodes.length; i++) {
     const node = el.childNodes[i];
@@ -69,7 +69,16 @@ export function getTextContent(el: Element): string | undefined {
   if (!trimmed) {
     return undefined;
   }
-  return trimmed.substring(0, MAX_TEXT_LENGTH);
+  if (maxTextLength === null) {
+    return trimmed;
+  }
+
+  const effectiveMaxTextLength = maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH;
+  if (effectiveMaxTextLength <= 0) {
+    throw new Error('collectorMaxTextLength must be positive or null');
+  }
+
+  return trimmed.substring(0, effectiveMaxTextLength);
 }
 
 /**

--- a/src/firefox/snapshot/injected/snapshot.injected.ts
+++ b/src/firefox/snapshot/injected/snapshot.injected.ts
@@ -11,6 +11,7 @@ import type { TreeWalkerResult } from './treeWalker.js';
  */
 export interface CreateSnapshotOptions extends TreeWalkerOptions {
   selector?: string;
+  formatterMaxTextLength?: number | null;
 }
 
 /**
@@ -60,6 +61,9 @@ export function createSnapshot(
     };
     if (options?.includeAll !== undefined) {
       treeOptions.includeAll = options.includeAll;
+    }
+    if (options?.collectorMaxTextLength !== undefined) {
+      treeOptions.collectorMaxTextLength = options.collectorMaxTextLength;
     }
     const result = walkTree(rootElement, snapshotId, treeOptions);
 

--- a/src/firefox/snapshot/injected/treeWalker.ts
+++ b/src/firefox/snapshot/injected/treeWalker.ts
@@ -24,6 +24,7 @@ const MAX_NODES = 1000;
 export interface TreeWalkerOptions {
   includeAll?: boolean;
   includeIframes?: boolean;
+  collectorMaxTextLength?: number | null;
 }
 
 /**
@@ -51,7 +52,7 @@ export function walkTree(
   snapshotId: number,
   options: TreeWalkerOptions = {}
 ): TreeWalkerResult {
-  const { includeAll = false, includeIframes = true } = options;
+  const { includeAll = false, includeIframes = true, collectorMaxTextLength } = options;
 
   let counter = 0;
   const uidMap: UidEntry[] = [];
@@ -145,8 +146,8 @@ export function walkTree(
     // Collect attributes
     const htmlEl = el as HTMLElement;
     const roleAttr = el.getAttribute('role');
-    const nameAttr = getElementName(el);
-    const textAttr = getTextContent(el);
+    const nameAttr = getElementName(el, collectorMaxTextLength);
+    const textAttr = getTextContent(el, collectorMaxTextLength);
     const valueAttr = (htmlEl as any).value;
     const hrefAttr = (htmlEl as any).href;
     const srcAttr = (htmlEl as any).src;

--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -18,6 +18,8 @@ import { UidResolver } from './resolver.js';
 export interface SnapshotOptions {
   includeAll?: boolean;
   selector?: string;
+  collectorMaxTextLength?: number | null;
+  formatterMaxTextLength?: number | null;
 }
 
 /**
@@ -138,7 +140,9 @@ export class SnapshotManager {
     };
 
     const snapshot: Snapshot = {
-      text: formatSnapshotTree(result.tree),
+      text: formatSnapshotTree(result.tree, 0, {
+        maxTextLength: options?.formatterMaxTextLength,
+      }),
       json: snapshotJson,
     };
 

--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -139,10 +139,13 @@ export class SnapshotManager {
       uidMap: result.uidMap,
     };
 
+    const formatOptions =
+      options?.formatterMaxTextLength === undefined
+        ? {}
+        : { maxTextLength: options.formatterMaxTextLength };
+
     const snapshot: Snapshot = {
-      text: formatSnapshotTree(result.tree, 0, {
-        maxTextLength: options?.formatterMaxTextLength,
-      }),
+      text: formatSnapshotTree(result.tree, 0, formatOptions),
       json: snapshotJson,
     };
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -43,12 +43,12 @@ export const takeSnapshotTool = {
       collectorMaxTextLength: {
         anyOf: [{ type: 'number' }, { type: 'null' }],
         description:
-          'Per-node text cap during snapshot collection. Omit to use default, set null for no cap.',
+          'Per-node text cap during snapshot collection. Omit to use the default compact preview behavior, set null for uncapped text.',
       },
       formatterMaxTextLength: {
         anyOf: [{ type: 'number' }, { type: 'null' }],
         description:
-          'Per-node text cap when formatting snapshot output. Omit to use default, set null for no cap.',
+          'Per-node text cap when formatting snapshot output. Omit to use the default compact preview behavior, set null for uncapped text.',
       },
     },
   },

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -40,6 +40,16 @@ export const takeSnapshotTool = {
         type: 'string',
         description: 'CSS selector to scope snapshot to specific element (e.g., "#app")',
       },
+      collectorMaxTextLength: {
+        anyOf: [{ type: 'number' }, { type: 'null' }],
+        description:
+          'Per-node text cap during snapshot collection. Omit to use default, set null for no cap.',
+      },
+      formatterMaxTextLength: {
+        anyOf: [{ type: 'number' }, { type: 'null' }],
+        description:
+          'Per-node text cap when formatting snapshot output. Omit to use default, set null for no cap.',
+      },
     },
   },
 };
@@ -78,6 +88,8 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth,
       includeAll = false,
       selector,
+      collectorMaxTextLength,
+      formatterMaxTextLength,
     } = (args as {
       maxLines?: number;
       includeAttributes?: boolean;
@@ -85,7 +97,12 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth?: number;
       includeAll?: boolean;
       selector?: string;
+      collectorMaxTextLength?: number | null;
+      formatterMaxTextLength?: number | null;
     }) || {};
+
+    validateTextLengthControl('collectorMaxTextLength', collectorMaxTextLength);
+    validateTextLengthControl('formatterMaxTextLength', formatterMaxTextLength);
 
     // Apply hard cap on maxLines to prevent token overflow
     const maxLines = Math.min(Math.max(1, requestedMaxLines), TOKEN_LIMITS.MAX_SNAPSHOT_LINES_CAP);
@@ -102,6 +119,12 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
     if (selector) {
       snapshotOptions.selector = selector;
     }
+    if (collectorMaxTextLength !== undefined) {
+      snapshotOptions.collectorMaxTextLength = collectorMaxTextLength;
+    }
+    if (formatterMaxTextLength !== undefined) {
+      snapshotOptions.formatterMaxTextLength = formatterMaxTextLength;
+    }
     const snapshot = await firefox.takeSnapshot(
       Object.keys(snapshotOptions).length > 0 ? snapshotOptions : undefined
     );
@@ -114,6 +137,9 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
     };
     if (maxDepth !== undefined) {
       options.maxDepth = maxDepth;
+    }
+    if (formatterMaxTextLength !== undefined) {
+      options.maxTextLength = formatterMaxTextLength;
     }
     const formattedText = formatSnapshotTree(snapshot.json.root, 0, options);
 
@@ -154,6 +180,18 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
           'The page may not be fully loaded or accessible.'
       )
     );
+  }
+}
+
+function validateTextLengthControl(
+  name: 'collectorMaxTextLength' | 'formatterMaxTextLength',
+  value: number | null | undefined
+): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number or null`);
   }
 }
 

--- a/tests/firefox/snapshot/injected/snapshot.injected.test.ts
+++ b/tests/firefox/snapshot/injected/snapshot.injected.test.ts
@@ -108,6 +108,22 @@ describe('snapshot.injected - createSnapshot', () => {
     });
   });
 
+  describe('collectorMaxTextLength option', () => {
+    it('truncates collected direct text when a numeric cap is provided', () => {
+      document.body.innerHTML = '<div>abcdefghijklmnopqrstuvwxyz</div>';
+
+      const result = createSnapshot(1, { collectorMaxTextLength: 5 });
+      expect(result.tree?.children[0]?.text).toBe('abcde');
+    });
+
+    it('preserves full direct text when set to null', () => {
+      document.body.innerHTML = '<div>abcdefghijklmnopqrstuvwxyz</div>';
+
+      const result = createSnapshot(1, { collectorMaxTextLength: null });
+      expect(result.tree?.children[0]?.text).toBe('abcdefghijklmnopqrstuvwxyz');
+    });
+  });
+
   describe('window global', () => {
     it('registers __createSnapshot on window', () => {
       expect((window as any).__createSnapshot).toBeDefined();

--- a/tests/snapshot/formatter.test.ts
+++ b/tests/snapshot/formatter.test.ts
@@ -174,6 +174,34 @@ describe('Snapshot Formatter', () => {
       expect(result.length).toBeLessThan(longText.length + 50);
     });
 
+    it('should respect an explicit formatter text cap', () => {
+      const node: SnapshotNode = {
+        uid: 'uid-8b',
+        role: 'text',
+        tag: 'span',
+        text: 'abcdefghijklmnopqrstuvwxyz',
+        children: [],
+      };
+
+      const result = formatSnapshotTree(node, 0, { maxTextLength: 10 });
+      expect(result).toContain('text="abcdefg..."');
+    });
+
+    it('should preserve full text when formatter maxTextLength is null', () => {
+      const longText = 'abcdefghijklmnopqrstuvwxyz';
+      const node: SnapshotNode = {
+        uid: 'uid-8c',
+        role: 'text',
+        tag: 'span',
+        text: longText,
+        children: [],
+      };
+
+      const result = formatSnapshotTree(node, 0, { maxTextLength: null });
+      expect(result).toContain(`text="${longText}"`);
+      expect(result).not.toContain('...');
+    });
+
     it('should show tag when role differs from tag', () => {
       const node: SnapshotNode = {
         uid: 'uid-9',

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -60,6 +60,20 @@ describe('Snapshot Tools', () => {
       expect(properties?.selector.type).toBe('string');
     });
 
+    it('takeSnapshotTool should expose text truncation controls', () => {
+      const { properties } = takeSnapshotTool.inputSchema;
+      expect(properties?.collectorMaxTextLength).toBeDefined();
+      expect(properties?.formatterMaxTextLength).toBeDefined();
+      expect(properties?.collectorMaxTextLength.anyOf).toEqual([
+        { type: 'number' },
+        { type: 'null' },
+      ]);
+      expect(properties?.formatterMaxTextLength.anyOf).toEqual([
+        { type: 'number' },
+        { type: 'null' },
+      ]);
+    });
+
     it('resolveUidToSelectorTool should require uid', () => {
       const { properties, required } = resolveUidToSelectorTool.inputSchema;
       expect(properties).toBeDefined();


### PR DESCRIPTION
## Summary
- add `collectorMaxTextLength` and `formatterMaxTextLength` to `take_snapshot`
- support omitted values for defaults and `null` for uncapped node text
- wire both truncation stages through the tool API, tests, and README guidance

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:run -- tests/tools/snapshot.test.ts tests/firefox/snapshot/injected/snapshot.injected.test.ts tests/snapshot/formatter.test.ts`

Closes #17