### PR TITLE
feat: support uid-rooted snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Then call tools like:
 - `take_snapshot` then `click_by_uid` / `fill_by_uid`
   - use `collectorMaxTextLength` and `formatterMaxTextLength` to control per-node text truncation
   - omit the values for default compact previews, set them to `null` for uncapped node text
+  - pass `uid` to zoom into a previously discovered subtree root while keeping unchanged UIDs stable
 - `list_network_requests` (always‑on capture), `get_network_request`
 - `screenshot_page`, `list_console_messages`
 

--- a/docs/firefox-client.md
+++ b/docs/firefox-client.md
@@ -211,7 +211,7 @@ The server provides comprehensive browser automation tools:
 | Tool | Description | Implementation |
 |------|------------|----------------|
 | `take_screenshot` | Capture screenshot (PNG) | `driver.takeScreenshot()` |
-| `take_snapshot` | Get HTML content | `driver.executeScript('return document.documentElement.outerHTML')` |
+| `take_snapshot` | Capture a structured DOM snapshot with stable UIDs | Bundled injected tree walker + snapshot formatter |
 | `evaluate_script` | Execute JavaScript | `driver.executeScript(script)` |
 
 ### Developer Tools

--- a/src/firefox/snapshot/injected/snapshot.injected.ts
+++ b/src/firefox/snapshot/injected/snapshot.injected.ts
@@ -12,6 +12,9 @@ import type { TreeWalkerResult } from './treeWalker.js';
 export interface CreateSnapshotOptions extends TreeWalkerOptions {
   selector?: string;
   formatterMaxTextLength?: number | null;
+  uid?: string;
+  rootCss?: string;
+  rootXPath?: string | null;
 }
 
 /**
@@ -19,6 +22,7 @@ export interface CreateSnapshotOptions extends TreeWalkerOptions {
  */
 export interface CreateSnapshotResult extends TreeWalkerResult {
   selectorError?: string;
+  uidError?: string;
 }
 
 /**
@@ -33,7 +37,18 @@ export function createSnapshot(
     // Determine root element
     let rootElement: Element = document.body;
 
-    if (options?.selector) {
+    if (options?.rootXPath || options?.rootCss) {
+      const selected = resolveRootElement(options.rootXPath, options.rootCss);
+      if (!selected) {
+        return {
+          tree: null,
+          uidMap: [],
+          truncated: false,
+          uidError: `Root UID target not found. Take a fresh snapshot first.`,
+        };
+      }
+      rootElement = selected;
+    } else if (options?.selector) {
       try {
         const selected = document.querySelector(options.selector);
         if (!selected) {
@@ -65,6 +80,15 @@ export function createSnapshot(
     if (options?.collectorMaxTextLength !== undefined) {
       treeOptions.collectorMaxTextLength = options.collectorMaxTextLength;
     }
+    if (options?.existingUidMap !== undefined) {
+      treeOptions.existingUidMap = options.existingUidMap;
+    }
+    if (options?.nextUidCounter !== undefined) {
+      treeOptions.nextUidCounter = options.nextUidCounter;
+    }
+    if (options?.uid !== undefined) {
+      treeOptions.includeRoot = true;
+    }
     const result = walkTree(rootElement, snapshotId, treeOptions);
 
     if (!result.tree) {
@@ -84,4 +108,34 @@ export function createSnapshot(
 // Make it available globally for executeScript
 if (typeof window !== 'undefined') {
   (window as any).__createSnapshot = createSnapshot;
+}
+
+function resolveRootElement(rootXPath?: string | null, rootCss?: string): Element | null {
+  if (rootXPath) {
+    try {
+      const xpathResult = document.evaluate(
+        rootXPath,
+        document,
+        null,
+        XPathResult.FIRST_ORDERED_NODE_TYPE,
+        null
+      );
+      if (xpathResult.singleNodeValue instanceof Element) {
+        return xpathResult.singleNodeValue;
+      }
+    } catch {
+      // Fall back to CSS lookup below.
+    }
+  }
+
+  if (!rootCss) {
+    return null;
+  }
+
+  try {
+    const cssResult = document.querySelector(rootCss);
+    return cssResult instanceof Element ? cssResult : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/firefox/snapshot/injected/treeWalker.ts
+++ b/src/firefox/snapshot/injected/treeWalker.ts
@@ -25,6 +25,9 @@ export interface TreeWalkerOptions {
   includeAll?: boolean;
   includeIframes?: boolean;
   collectorMaxTextLength?: number | null;
+  existingUidMap?: UidEntry[];
+  nextUidCounter?: number;
+  includeRoot?: boolean;
 }
 
 /**
@@ -52,11 +55,27 @@ export function walkTree(
   snapshotId: number,
   options: TreeWalkerOptions = {}
 ): TreeWalkerResult {
-  const { includeAll = false, includeIframes = true, collectorMaxTextLength } = options;
+  const {
+    includeAll = false,
+    includeIframes = true,
+    collectorMaxTextLength,
+    existingUidMap = [],
+    nextUidCounter = 0,
+    includeRoot = false,
+  } = options;
 
-  let counter = 0;
+  let counter = nextUidCounter;
   const uidMap: UidEntry[] = [];
   let truncated = false;
+  const existingByCss = new Map<string, UidEntry>();
+  const existingByXPath = new Map<string, UidEntry>();
+
+  for (const entry of existingUidMap) {
+    existingByCss.set(entry.css, entry);
+    if (entry.xpath) {
+      existingByXPath.set(entry.xpath, entry);
+    }
+  }
 
   function walk(el: Element, depth: number): WalkResult {
     // Check limits
@@ -72,16 +91,17 @@ export function walkTree(
 
     // Check relevance (except root)
     const tag = el.tagName.toLowerCase();
-    const isRoot = tag === 'body' || tag === 'html';
+    const isRoot = depth === 0;
+    const isDocumentRoot = tag === 'body' || tag === 'html';
 
     // Determine if element is relevant based on mode
     let elementIsRelevant: boolean;
     if (includeAll) {
       // Include all mode: only check visibility
-      elementIsRelevant = isRoot || isVisible(el);
+      elementIsRelevant = (includeRoot && isRoot) || isDocumentRoot || isVisible(el);
     } else {
       // Standard mode: use full relevance filter
-      elementIsRelevant = isRoot || isRelevant(el);
+      elementIsRelevant = (includeRoot && isRoot) || isDocumentRoot || isRelevant(el);
     }
 
     // Always walk children first (bubble-up pattern)
@@ -137,9 +157,11 @@ export function walkTree(
     }
 
     // Element IS relevant - create node
-    const uid = `${snapshotId}_${counter++}`;
     const css = generateCssSelector(el);
     const xpath = generateXPath(el);
+    const existingEntry =
+      existingByCss.get(css) ?? (xpath ? existingByXPath.get(xpath) : undefined);
+    const uid = existingEntry?.uid ?? `${snapshotId}_${counter++}`;
 
     uidMap.push({ uid, css, xpath });
 

--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -18,6 +18,7 @@ import { UidResolver } from './resolver.js';
 export interface SnapshotOptions {
   includeAll?: boolean;
   selector?: string;
+  uid?: string;
   collectorMaxTextLength?: number | null;
   formatterMaxTextLength?: number | null;
 }
@@ -91,9 +92,22 @@ export class SnapshotManager {
    * Returns text and JSON with snapshotId, no DOM mutations
    */
   async takeSnapshot(options?: SnapshotOptions): Promise<Snapshot> {
-    const snapshotId = ++this.currentSnapshotId;
-    this.resolver.setSnapshotId(snapshotId);
-    this.resolver.clear();
+    const rootUid = options?.uid;
+    const isUidRootedSnapshot = rootUid !== undefined;
+    let snapshotId: number;
+
+    if (isUidRootedSnapshot) {
+      if (this.resolver.getSnapshotId() === 0) {
+        throw new Error(
+          'No active snapshot available for UID-rooted snapshot. Take a fresh snapshot first.'
+        );
+      }
+      snapshotId = this.resolver.getSnapshotId();
+    } else {
+      snapshotId = ++this.currentSnapshotId;
+      this.resolver.setSnapshotId(snapshotId);
+      this.resolver.clear();
+    }
 
     logDebug(`Taking snapshot (ID: ${snapshotId})...`);
 
@@ -120,6 +134,10 @@ export class SnapshotManager {
       logDebug(`Snapshot generation failed: ${result.selectorError}`);
       throw new Error(result.selectorError);
     }
+    if (result?.uidError) {
+      logDebug(`Snapshot generation failed: ${result.uidError}`);
+      throw new Error(result.uidError);
+    }
 
     if (!result?.tree) {
       const errorMsg = 'Unknown error';
@@ -128,7 +146,11 @@ export class SnapshotManager {
     }
 
     // Store UID mappings in resolver
-    this.resolver.storeUidMappings(result.uidMap);
+    if (isUidRootedSnapshot) {
+      this.resolver.mergeUidMappings(result.uidMap);
+    } else {
+      this.resolver.storeUidMappings(result.uidMap);
+    }
 
     // Create snapshot object
     const snapshotJson: SnapshotJson = {
@@ -185,6 +207,15 @@ export class SnapshotManager {
     options?: SnapshotOptions
   ): Promise<InjectedScriptResult> {
     const scriptSource = this.getInjectedScript();
+    const scriptOptions: Record<string, unknown> = { ...(options || {}) };
+
+    if (options?.uid) {
+      const rootEntry = this.resolver.getUidEntry(options.uid);
+      scriptOptions.rootCss = rootEntry.css;
+      scriptOptions.rootXPath = rootEntry.xpath ?? null;
+      scriptOptions.existingUidMap = this.resolver.getUidMappings();
+      scriptOptions.nextUidCounter = this.resolver.getNextUidCounter();
+    }
 
     // Inject and execute the bundled script
     // The script exposes window.__createSnapshot via IIFE global
@@ -203,7 +234,7 @@ export class SnapshotManager {
       return window.__createSnapshot(arguments[0], arguments[1]);
       `,
       snapshotId,
-      options || {}
+      scriptOptions
     );
 
     return result;

--- a/src/firefox/snapshot/resolver.ts
+++ b/src/firefox/snapshot/resolver.ts
@@ -50,6 +50,42 @@ export class UidResolver {
     }
   }
 
+  mergeUidMappings(uidMap: UidEntry[]): void {
+    for (const entry of uidMap) {
+      this.uidToEntry.set(entry.uid, entry);
+    }
+  }
+
+  getUidMappings(): UidEntry[] {
+    return Array.from(this.uidToEntry.values());
+  }
+
+  getNextUidCounter(): number {
+    let maxCounter = -1;
+
+    for (const uid of this.uidToEntry.keys()) {
+      const separator = uid.indexOf('_');
+      const counterPart = separator === -1 ? uid : uid.slice(separator + 1);
+      const counter = parseInt(counterPart, 10);
+      if (!isNaN(counter) && counter > maxCounter) {
+        maxCounter = counter;
+      }
+    }
+
+    return maxCounter + 1;
+  }
+
+  getUidEntry(uid: string): UidEntry {
+    this.validateUid(uid);
+
+    const entry = this.uidToEntry.get(uid);
+    if (!entry) {
+      throw new Error(`UID not found: ${uid}. Take a fresh snapshot first.`);
+    }
+
+    return entry;
+  }
+
   /**
    * Clear all UID mappings and cache
    */
@@ -84,14 +120,7 @@ export class UidResolver {
    * Resolve UID to CSS selector (with staleness check)
    */
   resolveUidToSelector(uid: string): string {
-    this.validateUid(uid);
-
-    const entry = this.uidToEntry.get(uid);
-    if (!entry) {
-      throw new Error(`UID not found: ${uid}. Take a fresh snapshot first.`);
-    }
-
-    return entry.css;
+    return this.getUidEntry(uid).css;
   }
 
   /**
@@ -101,10 +130,7 @@ export class UidResolver {
   async resolveUidToElement(uid: string): Promise<WebElement> {
     this.validateUid(uid);
 
-    const entry = this.uidToEntry.get(uid);
-    if (!entry) {
-      throw new Error(`UID not found: ${uid}. Take a fresh snapshot first.`);
-    }
+    const entry = this.getUidEntry(uid);
 
     // Check cache
     const cached = this.elementCache.get(uid);

--- a/src/firefox/snapshot/types.ts
+++ b/src/firefox/snapshot/types.ts
@@ -91,6 +91,7 @@ export interface InjectedScriptResult {
   error?: string;
   truncated?: boolean;
   selectorError?: string;
+  uidError?: string;
   debugLog?: Array<{ el: string; relevant: boolean; depth: number }>;
 }
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -40,6 +40,11 @@ export const takeSnapshotTool = {
         type: 'string',
         description: 'CSS selector to scope snapshot to specific element (e.g., "#app")',
       },
+      uid: {
+        type: 'string',
+        description:
+          'Optional UID to use as the subtree root. Omit for the document root. maxDepth becomes relative to this root.',
+      },
       collectorMaxTextLength: {
         anyOf: [{ type: 'number' }, { type: 'null' }],
         description:
@@ -88,6 +93,7 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth,
       includeAll = false,
       selector,
+      uid,
       collectorMaxTextLength,
       formatterMaxTextLength,
     } = (args as {
@@ -97,12 +103,16 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
       maxDepth?: number;
       includeAll?: boolean;
       selector?: string;
+      uid?: string;
       collectorMaxTextLength?: number | null;
       formatterMaxTextLength?: number | null;
     }) || {};
 
     validateTextLengthControl('collectorMaxTextLength', collectorMaxTextLength);
     validateTextLengthControl('formatterMaxTextLength', formatterMaxTextLength);
+    if (selector !== undefined && uid !== undefined) {
+      throw new Error('selector and uid cannot be used together');
+    }
 
     // Apply hard cap on maxLines to prevent token overflow
     const maxLines = Math.min(Math.max(1, requestedMaxLines), TOKEN_LIMITS.MAX_SNAPSHOT_LINES_CAP);
@@ -118,6 +128,9 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
     }
     if (selector) {
       snapshotOptions.selector = selector;
+    }
+    if (uid) {
+      snapshotOptions.uid = uid;
     }
     if (collectorMaxTextLength !== undefined) {
       snapshotOptions.collectorMaxTextLength = collectorMaxTextLength;
@@ -153,6 +166,9 @@ export async function handleTakeSnapshot(args: unknown): Promise<McpToolResponse
     let output = `📸 Snapshot (id=${snapshot.json.snapshotId})`;
     if (selector) {
       output += ` [selector: ${selector}]`;
+    }
+    if (uid) {
+      output += ` [uid root: ${uid}]`;
     }
     if (includeAll) {
       output += ' [includeAll: true]';

--- a/tests/firefox/snapshot/injected/treeWalker.test.ts
+++ b/tests/firefox/snapshot/injected/treeWalker.test.ts
@@ -68,6 +68,48 @@ describe('treeWalker', () => {
       const result = walkTree(document.body, 1);
       expect(result.truncated).toBe(false);
     });
+
+    it('reuses existing UIDs when selectors match', () => {
+      document.body.innerHTML = '<section id="root"><button id="submit">OK</button></section>';
+
+      const initial = walkTree(document.body, 1);
+      const existingEntries = initial.uidMap;
+
+      const subtreeRoot = document.querySelector('#root');
+      expect(subtreeRoot).not.toBeNull();
+
+      const rooted = walkTree(subtreeRoot!, 1, {
+        existingUidMap: existingEntries,
+        nextUidCounter: 99,
+      });
+
+      expect(rooted.tree?.uid).toBe(
+        existingEntries.find((entry) => entry.css.includes('#root'))?.uid
+      );
+      expect(rooted.uidMap.find((entry) => entry.css.includes('#submit'))?.uid).toBe(
+        existingEntries.find((entry) => entry.css.includes('#submit'))?.uid
+      );
+    });
+
+    it('assigns new UIDs after the existing counter for new nodes', () => {
+      document.body.innerHTML = '<section id="root"><button id="existing">Old</button></section>';
+
+      const initial = walkTree(document.body, 5);
+      const root = document.querySelector('#root');
+      expect(root).not.toBeNull();
+
+      const newButton = document.createElement('button');
+      newButton.id = 'new-button';
+      newButton.textContent = 'New';
+      root!.appendChild(newButton);
+
+      const rooted = walkTree(root!, 5, {
+        existingUidMap: initial.uidMap,
+        nextUidCounter: 3,
+      });
+
+      expect(rooted.uidMap.find((entry) => entry.css.includes('#new-button'))?.uid).toBe('5_3');
+    });
   });
 
   describe('bubble-up pattern', () => {

--- a/tests/firefox/snapshot/resolver.test.ts
+++ b/tests/firefox/snapshot/resolver.test.ts
@@ -70,6 +70,44 @@ describe('UidResolver', () => {
       // New UID should be found
       expect(resolver.resolveUidToSelector('2_button')).toBe('#new');
     });
+
+    it('should merge UID mappings into the current snapshot', () => {
+      const firstMap: UidEntry[] = [{ uid: '1_0', css: '#old', xpath: '//old' }];
+      const secondMap: UidEntry[] = [{ uid: '1_1', css: '#new', xpath: '//new' }];
+
+      resolver.setSnapshotId(1);
+      resolver.storeUidMappings(firstMap);
+      resolver.mergeUidMappings(secondMap);
+
+      expect(resolver.resolveUidToSelector('1_0')).toBe('#old');
+      expect(resolver.resolveUidToSelector('1_1')).toBe('#new');
+    });
+  });
+
+  describe('getUidMappings / getNextUidCounter / getUidEntry', () => {
+    beforeEach(() => {
+      resolver.setSnapshotId(3);
+      resolver.storeUidMappings([
+        { uid: '3_0', css: '#root', xpath: '//body' },
+        { uid: '3_4', css: '#child', xpath: '//button[@id="child"]' },
+      ]);
+    });
+
+    it('should return stored uid mappings', () => {
+      expect(resolver.getUidMappings()).toHaveLength(2);
+    });
+
+    it('should compute the next UID counter from stored mappings', () => {
+      expect(resolver.getNextUidCounter()).toBe(5);
+    });
+
+    it('should return a stored UID entry', () => {
+      expect(resolver.getUidEntry('3_4')).toEqual({
+        uid: '3_4',
+        css: '#child',
+        xpath: '//button[@id="child"]',
+      });
+    });
   });
 
   describe('validateUid', () => {

--- a/tests/integration/snapshot.integration.test.ts
+++ b/tests/integration/snapshot.integration.test.ts
@@ -171,6 +171,52 @@ describe('Snapshot Integration Tests', () => {
     );
   }, 10000);
 
+  it('should take a subtree snapshot rooted at a UID and preserve unchanged UIDs', async () => {
+    const fixturePath = `file://${fixturesPath}/e2e-app.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const broadSnapshot = await firefox.takeSnapshot({ maxDepth: 3 });
+    const todoPageEntry = broadSnapshot.json.uidMap.find((entry) => entry.css === 'div#todoPage');
+    const todoInputEntry = broadSnapshot.json.uidMap.find(
+      (entry) => entry.css === 'input#todoInput'
+    );
+
+    expect(todoPageEntry).toBeDefined();
+    expect(todoInputEntry).toBeDefined();
+
+    const subtreeSnapshot = await firefox.takeSnapshot({
+      uid: todoPageEntry!.uid,
+      maxDepth: 2,
+    });
+
+    expect(subtreeSnapshot.json.snapshotId).toBe(broadSnapshot.json.snapshotId);
+    expect(subtreeSnapshot.json.root.uid).toBe(todoPageEntry!.uid);
+    expect(subtreeSnapshot.json.uidMap.find((entry) => entry.css === 'input#todoInput')?.uid).toBe(
+      todoInputEntry!.uid
+    );
+  }, 10000);
+
+  it('should apply maxDepth relative to a UID-rooted subtree', async () => {
+    const fixturePath = `file://${fixturesPath}/e2e-app.html`;
+    await firefox.navigate(fixturePath);
+    await waitForPageLoad();
+
+    const broadSnapshot = await firefox.takeSnapshot({ maxDepth: 3 });
+    const todoPageEntry = broadSnapshot.json.uidMap.find((entry) => entry.css === 'div#todoPage');
+
+    expect(todoPageEntry).toBeDefined();
+
+    const shallowSubtree = await firefox.takeSnapshot({
+      uid: todoPageEntry!.uid,
+      maxDepth: 1,
+    });
+
+    const childTags = shallowSubtree.json.root.children.map((child) => child.tag);
+    expect(childTags).toContain('h2');
+    expect(childTags).toContain('div');
+  }, 10000);
+
   it('should exclude children of hidden parents even in includeAll mode', async () => {
     const fixturePath = `file://${fixturesPath}/visibility.html`;
     await firefox.navigate(fixturePath);

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -60,6 +60,12 @@ describe('Snapshot Tools', () => {
       expect(properties?.selector.type).toBe('string');
     });
 
+    it('takeSnapshotTool should have uid property with string type', () => {
+      const { properties } = takeSnapshotTool.inputSchema;
+      expect(properties?.uid).toBeDefined();
+      expect(properties?.uid.type).toBe('string');
+    });
+
     it('takeSnapshotTool should expose text truncation controls', () => {
       const { properties } = takeSnapshotTool.inputSchema;
       expect(properties?.collectorMaxTextLength).toBeDefined();


### PR DESCRIPTION
## Summary
- add `uid` as an optional subtree root for `take_snapshot`
- preserve unchanged UIDs across rooted snapshots on unchanged DOM
- document the zoom-in workflow and cover rooted snapshot behavior with unit and integration tests

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:run -- tests/tools/snapshot.test.ts tests/firefox/snapshot/resolver.test.ts tests/firefox/snapshot/injected/treeWalker.test.ts tests/integration/snapshot.integration.test.ts`

Closes #19