### PR TITLE
fix: improve snapshot error diagnostics

### DIFF
--- a/src/firefox/snapshot/injected/snapshot.injected.ts
+++ b/src/firefox/snapshot/injected/snapshot.injected.ts
@@ -23,6 +23,7 @@ export interface CreateSnapshotOptions extends TreeWalkerOptions {
 export interface CreateSnapshotResult extends TreeWalkerResult {
   selectorError?: string;
   uidError?: string;
+  snapshotError?: string;
 }
 
 /**
@@ -96,11 +97,12 @@ export function createSnapshot(
     }
 
     return result;
-  } catch {
+  } catch (error) {
     return {
       tree: null,
       uidMap: [],
       truncated: false,
+      snapshotError: getErrorMessage(error),
     };
   }
 }
@@ -138,4 +140,11 @@ function resolveRootElement(rootXPath?: string | null, rootCss?: string): Elemen
   } catch {
     return null;
   }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }

--- a/src/firefox/snapshot/manager.ts
+++ b/src/firefox/snapshot/manager.ts
@@ -138,6 +138,13 @@ export class SnapshotManager {
       logDebug(`Snapshot generation failed: ${result.uidError}`);
       throw new Error(result.uidError);
     }
+    if (result?.snapshotError) {
+      const errorMsg = options?.uid
+        ? `${result.snapshotError} The targeted subtree may have changed while the snapshot was being generated; take a fresh root snapshot and retry.`
+        : result.snapshotError;
+      logDebug(`Snapshot generation failed: ${errorMsg}`);
+      throw new Error(`Failed to generate snapshot: ${errorMsg}`);
+    }
 
     if (!result?.tree) {
       const errorMsg = 'Unknown error';

--- a/src/firefox/snapshot/types.ts
+++ b/src/firefox/snapshot/types.ts
@@ -92,6 +92,7 @@ export interface InjectedScriptResult {
   truncated?: boolean;
   selectorError?: string;
   uidError?: string;
+  snapshotError?: string;
   debugLog?: Array<{ el: string; relevant: boolean; depth: number }>;
 }
 

--- a/tests/firefox/snapshot/injected/snapshot.injected.test.ts
+++ b/tests/firefox/snapshot/injected/snapshot.injected.test.ts
@@ -130,4 +130,25 @@ describe('snapshot.injected - createSnapshot', () => {
       expect(typeof (window as any).__createSnapshot).toBe('function');
     });
   });
+
+  describe('error preservation', () => {
+    it('preserves unexpected snapshot errors instead of dropping them', () => {
+      const originalChildren = Object.getOwnPropertyDescriptor(Element.prototype, 'children');
+      const childrenGetter = vi
+        .spyOn(Element.prototype, 'children', 'get')
+        .mockImplementation(function (this: Element) {
+          if (this === document.body) {
+            throw new Error('dynamic subtree detached');
+          }
+          return originalChildren?.get?.call(this) ?? ([] as unknown as HTMLCollection);
+        });
+
+      const result = createSnapshot(1);
+
+      expect(result.tree).toBeNull();
+      expect(result.snapshotError).toContain('dynamic subtree detached');
+
+      childrenGetter.mockRestore();
+    });
+  });
 });

--- a/tests/firefox/snapshot/manager.test.ts
+++ b/tests/firefox/snapshot/manager.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SnapshotManager } from '@/firefox/snapshot/manager.js';
+import type { InjectedScriptResult } from '@/firefox/snapshot/types.js';
+
+describe('SnapshotManager', () => {
+  let manager: SnapshotManager;
+
+  beforeEach(() => {
+    manager = new SnapshotManager({} as never);
+  });
+
+  it('surfaces preserved injected snapshot errors', async () => {
+    vi.spyOn(manager as any, 'executeInjectedScript').mockResolvedValue({
+      tree: null,
+      uidMap: [],
+      truncated: false,
+      snapshotError: 'dynamic subtree detached',
+    } satisfies InjectedScriptResult);
+
+    await expect(manager.takeSnapshot()).rejects.toThrow(
+      'Failed to generate snapshot: dynamic subtree detached'
+    );
+  });
+
+  it('adds subtree guidance for uid-rooted snapshot errors', async () => {
+    (manager as any).resolver.setSnapshotId(7);
+
+    vi.spyOn(manager as any, 'executeInjectedScript').mockResolvedValue({
+      tree: null,
+      uidMap: [],
+      truncated: false,
+      snapshotError: 'target node replaced during walk',
+    } satisfies InjectedScriptResult);
+
+    await expect(manager.takeSnapshot({ uid: '7_0' })).rejects.toThrow(
+      'Failed to generate snapshot: target node replaced during walk The targeted subtree may have changed while the snapshot was being generated; take a fresh root snapshot and retry.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preserve real injected snapshot failures instead of collapsing them to `Unknown error`
- surface subtree-specific retry guidance for UID-rooted snapshot failures
- add unit and integration-adjacent coverage for the new diagnostics path

## Testing
- npm run format:check
- npm run typecheck
- npm run lint
- npm run test:run -- tests/firefox/snapshot/injected/snapshot.injected.test.ts tests/firefox/snapshot/manager.test.ts
- npm run test:run -- tests/tools/snapshot.test.ts
- npm run test:run -- tests/integration/snapshot.integration.test.ts

Closes #21