### PR TITLE
feat: add workspace ownership metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,5 @@
 - [Migration to BiDi](./migration-to-bidi.md)
 - [Testing](./testing.md)
 - [Workspace Isolation Proposal](./workspace-isolation.md)
+- [Workspace Ownership First Slice](./workspace-ownership.md)
 - [Project Tracker](./tracking/project_tracker.md)

--- a/docs/tracking/project_tracker.md
+++ b/docs/tracking/project_tracker.md
@@ -2,18 +2,19 @@
 
 ## Current Focus
 
-- `#26` `feat: introduce workspace-scoped selected page and snapshot state`
+- `#28` `feat: add workspace tab ownership and human approval semantics`
   - Status: `in-progress`
-  - Current phase: first implementation slice
-  - Output target: workspace-scoped selected page/context plus workspace-scoped snapshot state
+  - Current phase: define the first ownership/approval slice on top of workspace-scoped state
+  - Output target: shared-by-default tab ownership model plus deny-by-default agent access to protected human space
 
 ## Recent Completed Work
 
+- `#26` introduced workspace-scoped selected page/context and workspace-scoped snapshot state
 - `#24` added the workspace isolation proposal and architecture baseline
 - `#21` improved snapshot failure diagnostics so `take_snapshot` preserves real injected errors instead of collapsing to `Unknown error`
 
 ## Next Likely Steps
 
-1. Finish the workspace-state split and land the first implementation slice
-2. Validate which additional tools need explicit workspace-awareness next
-3. Split follow-up issues for ownership, locking, and human approval semantics
+1. Define stable Firewatch-side tab identity so ownership does not depend on mutable tab indices
+2. Enforce human-vs-agent and agent-vs-agent access rules on top of workspace state
+3. Extend the ownership model into the tool surfaces that can currently act without approval context

--- a/docs/workspace-isolation.md
+++ b/docs/workspace-isolation.md
@@ -111,14 +111,17 @@ Each workspace should eventually own:
 
 Pages/tabs should have explicit ownership semantics:
 
+- `shared` (default)
 - `human-owned`
 - `agent-owned`
-- `shared`
 
 Expected rules:
 
+- `shared` should remain the default mode unless there is a reason to restrict access
 - agents should not silently take over a `human-owned` tab
-- `shared` tabs should require explicit conflict rules
+- an `agent-owned` tab should be reserved for the owning agent plus the human supervisor
+- other agents should not silently enter another agent's owned tab unless it is explicitly shared
+- `shared` tabs still need explicit conflict rules
 - the system should make handoff visible instead of implicit
 
 ### Workspace access model
@@ -140,6 +143,18 @@ Recommended baseline:
   - other agents: denied by default unless explicitly shared
 
 This keeps delegation safe while preserving human visibility and override.
+
+### Default sharing rule
+
+Ownership should be treated as an override/protection layer, not as the default state for all tabs.
+
+Recommended default:
+
+- tabs/pages start as `shared`
+- a tab becomes `human-owned` when the human explicitly protects it or when the system needs to preserve the human's active work area
+- a tab becomes `agent-owned` when an agent opens or claims it as its own work surface
+
+This preserves the collaborative browsing model while still allowing stronger boundaries where needed.
 
 ### Isolation levels
 
@@ -311,6 +326,25 @@ interface WorkspaceState {
   snapshot: SnapshotState;
 }
 ```
+
+Introduce a tab/page ownership record alongside the workspace state:
+
+```ts
+type TabOwnership = 'shared' | 'human-owned' | 'agent-owned';
+
+interface TabState {
+  tabId: string;
+  contextId: string;
+  ownership: TabOwnership;
+  ownerWorkspaceId: string | null;
+}
+```
+
+Notes:
+
+- `tabId` should be a Firewatch-stable identifier, not just the current tab index
+- `ownerWorkspaceId` should be `null` for `shared` tabs
+- `agent-owned` means the owning agent workspace is the default operator, but the human can always inspect or take over
 
 Where `SnapshotState` contains:
 

--- a/docs/workspace-ownership.md
+++ b/docs/workspace-ownership.md
@@ -1,0 +1,185 @@
+# Workspace Ownership First Slice
+
+## Summary
+
+`#28` builds on `#26` by adding ownership and approval semantics on top of the new workspace-scoped state model.
+
+The goal is not full browser isolation yet. The goal is to define a correct control model for:
+
+- `shared` tabs/pages by default
+- `human-owned` protected areas
+- `agent-owned` work areas
+- human override and takeover
+- agent-vs-agent boundaries
+
+## Why This Needs a Design Pass First
+
+The current implementation from `#26` separates browsing state by `workspaceId`, but it does **not** yet have a separate notion of:
+
+- who is making a request
+- which workspace that caller belongs to
+- whether a call is acting in its own workspace or crossing into another workspace
+
+Today, many tools simply accept an optional `workspaceId`.
+
+That means the system can distinguish:
+
+- "act in workspace `human`"
+- "act in workspace `agent-a`"
+
+but it cannot yet distinguish:
+
+- "the human is acting in workspace `human`"
+- "agent B is trying to act in workspace `human`"
+
+Those are not the same thing, and approval semantics depend on the difference.
+
+## First Principle
+
+`workspaceId` and caller identity must not be treated as the same concept.
+
+We need both:
+
+- **caller identity**
+  - who is making the request
+  - examples: `human`, `agent-a`, `agent-b`
+- **target workspace**
+  - which workspace the tool should act in
+  - examples: `human`, `agent-a`, `shared-research`
+
+Without that distinction, deny-by-default access rules for the human workspace are not enforceable in a trustworthy way.
+
+## Ownership Model
+
+Tabs/pages should support three ownership modes:
+
+- `shared`
+- `human-owned`
+- `agent-owned`
+
+### Intended semantics
+
+#### `shared`
+
+This should be the default mode.
+
+Meaning:
+
+- human can use it
+- agent A can use it
+- agent B can use it
+- conflicts still need coordination, but access is not restricted by default
+
+#### `human-owned`
+
+Meaning:
+
+- human can use it freely
+- agents require explicit approval or handoff
+
+This is the protected mode for the human's active work area.
+
+#### `agent-owned`
+
+Meaning:
+
+- the owning agent can use it normally
+- the human can always inspect, enter, and take over
+- other agents are denied by default unless the tab is explicitly shared
+
+This is the main agent-vs-agent boundary.
+
+## Tab Identity Requirement
+
+Tab indices are not sufficient for ownership.
+
+Why:
+
+- indices change when tabs open or close
+- indices can shift when the human changes tab order
+- ownership needs a stable identity that survives reordering
+
+So ownership should attach to a Firewatch-side stable tab record, not to a mutable tab index.
+
+Suggested internal model:
+
+```ts
+type WorkspaceId = string;
+type TabOwnership = 'shared' | 'human-owned' | 'agent-owned';
+
+interface TabState {
+  tabId: string;
+  contextId: string;
+  ownership: TabOwnership;
+  ownerWorkspaceId: WorkspaceId | null;
+}
+```
+
+Notes:
+
+- `tabId` is a Firewatch-stable identifier
+- `contextId` is the live Firefox/driver identity
+- `ownerWorkspaceId` is `null` for `shared` tabs
+
+## Required Coordinator Layer
+
+Mutating actions should eventually go through a single decision point.
+
+Examples:
+
+- `select_page`
+- `navigate_page`
+- `new_page`
+- `close_page`
+- click/fill/drag actions
+
+The coordinator should answer:
+
+- who is calling?
+- which workspace is targeted?
+- which tab is affected?
+- what is the ownership mode?
+- is this allowed?
+- does this require approval or handoff?
+
+This does **not** require a giant global queue for all actions, but it does require a central policy check for conflicting or cross-workspace mutations.
+
+## Recommended First Slice for `#28`
+
+Keep the first slice narrow.
+
+### In scope
+
+- define explicit ownership semantics in docs and internal types
+- introduce a stable Firewatch-side tab identity concept
+- track ownership state alongside tab metadata
+- make `shared` the default
+- define the rule that `agent-owned` excludes other agents by default but never the human
+- define the rule that `human-owned` denies agent access by default
+
+### Not yet in scope
+
+- full approval UI
+- dedicated windows
+- profile isolation
+- complete background execution
+- final queue/locking implementation
+
+## Open Constraint
+
+Real approval enforcement requires a caller identity model in addition to `workspaceId`.
+
+That is the key architectural constraint discovered at the start of `#28`.
+
+So the likely sequence is:
+
+1. define ownership + stable tab identity
+2. define caller identity vs target workspace semantics
+3. then enforce human/agent approval rules in tool behavior
+
+## Relationship to Other Work
+
+- `#24` defined the workspace-isolation architecture direction
+- `#26` implemented workspace-scoped selected page/context and snapshot state
+- `#28` should add ownership/control semantics on top of that base
+- `#22` remains a separate follow-up about resilient target re-identification, not the immediate next layer in the workspace architecture

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -12,11 +12,30 @@ import { PageManagement } from './pages.js';
 import { SnapshotManager, type Snapshot, type SnapshotOptions } from './snapshot/index.js';
 
 const DEFAULT_WORKSPACE_ID = 'human';
+const DEFAULT_CALLER_ID = 'human';
+
+type TabOwnership = 'shared' | 'human-owned' | 'agent-owned';
 
 interface WorkspaceState {
   selectedTabIndex: number;
   currentContextId: string | null;
   snapshot: SnapshotManager;
+}
+
+interface TabState {
+  tabId: string;
+  contextId: string;
+  ownership: TabOwnership;
+  ownerWorkspaceId: string | null;
+}
+
+interface BrowserTab {
+  actor: string;
+  title: string;
+  url: string;
+  tabId: string;
+  ownership: TabOwnership;
+  ownerWorkspaceId: string | null;
 }
 
 /**
@@ -29,6 +48,8 @@ export class FirefoxClient {
   private networkEvents: NetworkEvents | null = null;
   private pages: PageManagement | null = null;
   private workspaces = new Map<string, WorkspaceState>();
+  private tabs = new Map<string, TabState>();
+  private nextTabIdCounter = 1;
 
   constructor(options: FirefoxLaunchOptions) {
     this.core = new FirefoxCore(options);
@@ -87,6 +108,7 @@ export class FirefoxClient {
     defaultWorkspace.currentContextId = currentContextId;
 
     await this.pages.refreshTabs();
+    this.syncTabState();
     defaultWorkspace.selectedTabIndex = this.pages.getSelectedTabIdx();
 
     // Subscribe to console and network events for ALL contexts (not just current).
@@ -128,46 +150,58 @@ export class FirefoxClient {
 
   async extractText(
     options: ExtractTextOptions = {},
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<string> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.extractText(options);
   }
 
-  async clickBySelector(selector: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+  async clickBySelector(
+    selector: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.clickBySelector(selector);
   }
 
-  async hoverBySelector(selector: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+  async hoverBySelector(
+    selector: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.hoverBySelector(selector);
   }
 
   async fillBySelector(
     selector: string,
     text: string,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.fillBySelector(selector, text);
   }
 
   async dragAndDropBySelectors(
     sourceSelector: string,
     targetSelector: string,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.dragAndDropBySelectors(sourceSelector, targetSelector);
   }
 
   async uploadFileBySelector(
     selector: string,
     filePath: string,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.uploadFileBySelector(selector, filePath);
   }
 
@@ -176,45 +210,58 @@ export class FirefoxClient {
   async clickByUid(
     uid: string,
     dblClick = false,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.clickByUid(uid, dblClick);
   }
 
-  async hoverByUid(uid: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+  async hoverByUid(
+    uid: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.hoverByUid(uid);
   }
 
-  async fillByUid(uid: string, value: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+  async fillByUid(
+    uid: string,
+    value: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.fillByUid(uid, value);
   }
 
   async dragByUidToUid(
     fromUid: string,
     toUid: string,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.dragByUidToUid(fromUid, toUid);
   }
 
   async fillFormByUid(
     elements: Array<{ uid: string; value: string }>,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.fillFormByUid(elements);
   }
 
   async uploadFileByUid(
     uid: string,
     filePath: string,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
-    const dom = await this.getDom(workspaceId);
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.uploadFileByUid(uid, filePath);
   }
 
@@ -244,64 +291,90 @@ export class FirefoxClient {
   // Pages / Navigation
   // ============================================================================
 
-  async navigate(url: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async navigate(
+    url: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     await this.pages.navigate(url);
     this.getWorkspaceState(workspaceId).snapshot.clear();
   }
 
-  async navigateBack(workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async navigateBack(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.pages.navigateBack();
   }
 
-  async navigateForward(workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async navigateForward(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.pages.navigateForward();
   }
 
   async setViewportSize(
     width: number,
     height: number,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.pages.setViewportSize(width, height);
   }
 
-  async acceptDialog(promptText?: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async acceptDialog(
+    promptText?: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.pages.acceptDialog(promptText);
   }
 
-  async dismissDialog(workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async dismissDialog(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.pages.dismissDialog();
   }
 
-  getTabs(): Array<{ actor: string; title: string; url: string }> {
+  getTabs(): BrowserTab[] {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    return this.pages.getTabs();
+    return this.pages.getTabs().map((tab) => {
+      const tabState = this.tabs.get(tab.actor);
+      return {
+        ...tab,
+        tabId: tabState?.tabId ?? this.buildEphemeralTabId(tab.actor),
+        ownership: tabState?.ownership ?? 'shared',
+        ownerWorkspaceId: tabState?.ownerWorkspaceId ?? null,
+      };
+    });
   }
 
   getSelectedTabIdx(workspaceId = DEFAULT_WORKSPACE_ID): number {
@@ -315,43 +388,64 @@ export class FirefoxClient {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    return await this.pages.refreshTabs();
+    await this.pages.refreshTabs();
+    this.syncTabState();
+    this.reconcileWorkspaceSelections();
   }
 
-  async selectTab(index: number, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async selectTab(
+    index: number,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
+    this.assertWorkspaceAccess(workspaceId, callerId);
     await this.pages.selectTab(index);
+    this.syncTabState();
+    this.reconcileWorkspaceSelections();
     const workspace = this.getWorkspaceState(workspaceId);
     workspace.selectedTabIndex = index;
     workspace.currentContextId = this.core.getCurrentContextId();
   }
 
-  async createNewPage(url: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<number> {
+  async createNewPage(
+    url: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<number> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
+    this.assertWorkspaceAccess(workspaceId, callerId);
     const newIdx = await this.pages.createNewPage(url);
+    await this.pages.refreshTabs();
+    this.syncTabState();
+    this.reconcileWorkspaceSelections();
     const workspace = this.getWorkspaceState(workspaceId);
     workspace.selectedTabIndex = newIdx;
     workspace.currentContextId = this.core.getCurrentContextId();
+    this.assignTabOwnership(workspace.currentContextId, workspaceId);
     workspace.snapshot.clear();
     return newIdx;
   }
 
-  async closeTab(index: number, workspaceId = DEFAULT_WORKSPACE_ID): Promise<void> {
+  async closeTab(
+    index: number,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<void> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     await this.pages.closeTab(index);
     await this.pages.refreshTabs();
+    this.syncTabState();
+    this.reconcileWorkspaceSelections();
 
     const workspace = this.getWorkspaceState(workspaceId);
-    const tabs = this.pages.getTabs();
-    workspace.selectedTabIndex =
-      tabs.length === 0 ? 0 : Math.min(workspace.selectedTabIndex, tabs.length - 1);
     workspace.currentContextId = this.core.getCurrentContextId();
     workspace.snapshot.clear();
   }
@@ -402,10 +496,11 @@ export class FirefoxClient {
 
   async takeSnapshot(
     options?: SnapshotOptions,
-    workspaceId = DEFAULT_WORKSPACE_ID
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
   ): Promise<Snapshot> {
     const workspace = this.getWorkspaceState(workspaceId);
-    await this.activateWorkspace(workspaceId);
+    await this.activateWorkspace(workspaceId, callerId);
     return await workspace.snapshot.takeSnapshot(options);
   }
 
@@ -413,8 +508,12 @@ export class FirefoxClient {
     return this.getWorkspaceState(workspaceId).snapshot.resolveUidToSelector(uid);
   }
 
-  async resolveUidToElement(uid: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<WebElement> {
-    await this.activateWorkspace(workspaceId);
+  async resolveUidToElement(
+    uid: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<WebElement> {
+    await this.activateWorkspace(workspaceId, callerId);
     return await this.getWorkspaceState(workspaceId).snapshot.resolveUidToElement(uid);
   }
 
@@ -426,13 +525,20 @@ export class FirefoxClient {
   // Screenshot
   // ============================================================================
 
-  async takeScreenshotPage(workspaceId = DEFAULT_WORKSPACE_ID): Promise<string> {
-    const dom = await this.getDom(workspaceId);
+  async takeScreenshotPage(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<string> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.takeScreenshotPage();
   }
 
-  async takeScreenshotByUid(uid: string, workspaceId = DEFAULT_WORKSPACE_ID): Promise<string> {
-    const dom = await this.getDom(workspaceId);
+  async takeScreenshotByUid(
+    uid: string,
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<string> {
+    const dom = await this.getDom(workspaceId, callerId);
     return await dom.takeScreenshotByUid(uid);
   }
 
@@ -507,6 +613,8 @@ export class FirefoxClient {
     this.networkEvents = null;
     this.pages = null;
     this.workspaces.clear();
+    this.tabs.clear();
+    this.nextTabIdCounter = 1;
   }
 
   // ============================================================================
@@ -533,13 +641,19 @@ export class FirefoxClient {
     return workspace;
   }
 
-  private async activateWorkspace(workspaceId = DEFAULT_WORKSPACE_ID): Promise<WorkspaceState> {
+  private async activateWorkspace(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<WorkspaceState> {
     if (!this.pages) {
       throw new Error('Not connected');
     }
 
+    this.assertWorkspaceAccess(workspaceId, callerId);
     const workspace = this.getWorkspaceState(workspaceId);
     await this.pages.refreshTabs();
+    this.syncTabState();
+    this.reconcileWorkspaceSelections();
     const tabs = this.pages.getTabs();
 
     if (tabs.length === 0) {
@@ -570,11 +684,113 @@ export class FirefoxClient {
     return workspace;
   }
 
-  private async getDom(workspaceId = DEFAULT_WORKSPACE_ID): Promise<DomInteractions> {
-    await this.activateWorkspace(workspaceId);
+  private async getDom(
+    workspaceId = DEFAULT_WORKSPACE_ID,
+    callerId = DEFAULT_CALLER_ID
+  ): Promise<DomInteractions> {
+    await this.activateWorkspace(workspaceId, callerId);
     return new DomInteractions(this.core.getDriver(), (uid: string) =>
       this.getWorkspaceState(workspaceId).snapshot.resolveUidToElement(uid)
     );
+  }
+
+  private syncTabState(): void {
+    if (!this.pages) {
+      return;
+    }
+
+    const currentTabs = this.pages.getTabs();
+    const currentContextIds = new Set(currentTabs.map((tab) => tab.actor));
+
+    for (const tab of currentTabs) {
+      if (this.tabs.has(tab.actor)) {
+        continue;
+      }
+
+      this.tabs.set(tab.actor, {
+        tabId: `tab-${this.nextTabIdCounter++}`,
+        contextId: tab.actor,
+        ownership: 'shared',
+        ownerWorkspaceId: null,
+      });
+    }
+
+    for (const contextId of Array.from(this.tabs.keys())) {
+      if (!currentContextIds.has(contextId)) {
+        this.tabs.delete(contextId);
+      }
+    }
+  }
+
+  private assignTabOwnership(contextId: string | null, workspaceId: string): void {
+    if (!contextId) {
+      return;
+    }
+
+    const tabState = this.tabs.get(contextId);
+    if (!tabState) {
+      return;
+    }
+
+    if (workspaceId === DEFAULT_WORKSPACE_ID) {
+      tabState.ownership = 'shared';
+      tabState.ownerWorkspaceId = null;
+      return;
+    }
+
+    tabState.ownership = 'agent-owned';
+    tabState.ownerWorkspaceId = workspaceId;
+  }
+
+  private buildEphemeralTabId(contextId: string): string {
+    return `tab-unknown-${contextId}`;
+  }
+
+  private assertWorkspaceAccess(workspaceId: string, callerId: string): void {
+    if (callerId === DEFAULT_CALLER_ID) {
+      return;
+    }
+
+    if (workspaceId === DEFAULT_WORKSPACE_ID) {
+      throw new Error(
+        `Caller "${callerId}" is not allowed to act in the human workspace without explicit approval`
+      );
+    }
+
+    if (workspaceId !== callerId) {
+      throw new Error(
+        `Caller "${callerId}" is not allowed to act in workspace "${workspaceId}" by default`
+      );
+    }
+  }
+
+  private reconcileWorkspaceSelections(): void {
+    if (!this.pages) {
+      return;
+    }
+
+    const tabs = this.pages.getTabs();
+
+    for (const workspace of this.workspaces.values()) {
+      if (tabs.length === 0) {
+        workspace.selectedTabIndex = 0;
+        workspace.currentContextId = null;
+        continue;
+      }
+
+      const existingTabIndex = workspace.currentContextId
+        ? tabs.findIndex((tab) => tab.actor === workspace.currentContextId)
+        : -1;
+
+      if (existingTabIndex >= 0) {
+        workspace.selectedTabIndex = existingTabIndex;
+        continue;
+      }
+
+      const clampedIndex = Math.min(Math.max(workspace.selectedTabIndex, 0), tabs.length - 1);
+      workspace.selectedTabIndex = clampedIndex;
+      workspace.currentContextId = tabs[clampedIndex]?.actor ?? null;
+    }
   }
 }
 

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -9,6 +9,10 @@ const WORKSPACE_ID_SCHEMA = {
   type: 'string',
   description: 'Workspace identifier. Defaults to the human workspace when omitted.',
 } as const;
+const CALLER_ID_SCHEMA = {
+  type: 'string',
+  description: 'Caller identity. Defaults to the human caller when omitted.',
+} as const;
 
 // Tool definitions
 export const listPagesTool = {
@@ -18,6 +22,7 @@ export const listPagesTool = {
     type: 'object',
     properties: {
       workspaceId: WORKSPACE_ID_SCHEMA,
+      callerId: CALLER_ID_SCHEMA,
     },
   },
 };
@@ -33,6 +38,7 @@ export const newPageTool = {
         description: 'Target URL',
       },
       workspaceId: WORKSPACE_ID_SCHEMA,
+      callerId: CALLER_ID_SCHEMA,
     },
     required: ['url'],
   },
@@ -49,6 +55,7 @@ export const navigatePageTool = {
         description: 'Target URL',
       },
       workspaceId: WORKSPACE_ID_SCHEMA,
+      callerId: CALLER_ID_SCHEMA,
     },
     required: ['url'],
   },
@@ -73,6 +80,7 @@ export const selectPageTool = {
         description: 'Title substring (case-insensitive)',
       },
       workspaceId: WORKSPACE_ID_SCHEMA,
+      callerId: CALLER_ID_SCHEMA,
     },
     required: [],
   },
@@ -89,6 +97,7 @@ export const closePageTool = {
         description: 'Tab index to close',
       },
       workspaceId: WORKSPACE_ID_SCHEMA,
+      callerId: CALLER_ID_SCHEMA,
     },
     required: ['pageIdx'],
   },
@@ -98,7 +107,13 @@ export const closePageTool = {
  * Format page list compactly
  */
 function formatPageList(
-  tabs: Array<{ title?: string; url?: string }>,
+  tabs: Array<{
+    title?: string;
+    url?: string;
+    tabId?: string;
+    ownership?: string;
+    ownerWorkspaceId?: string | null;
+  }>,
   selectedIdx: number
 ): string {
   if (tabs.length === 0) {
@@ -109,7 +124,13 @@ function formatPageList(
     const idx = tabs.indexOf(tab);
     const marker = idx === selectedIdx ? '>' : ' ';
     const title = (tab.title || 'Untitled').substring(0, 40);
-    lines.push(`${marker}[${idx}] ${title}`);
+    const tabId = tab.tabId ? ` ${tab.tabId}` : '';
+    const ownership = tab.ownership
+      ? tab.ownerWorkspaceId
+        ? ` ${tab.ownership}:${tab.ownerWorkspaceId}`
+        : ` ${tab.ownership}`
+      : '';
+    lines.push(`${marker}[${idx}]${tabId}${ownership} ${title}`);
   }
   return lines.join('\n');
 }
@@ -133,7 +154,11 @@ export async function handleListPages(_args: unknown): Promise<McpToolResponse> 
 
 export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { url, workspaceId } = args as { url: string; workspaceId?: string };
+    const { url, workspaceId, callerId } = args as {
+      url: string;
+      workspaceId?: string;
+      callerId?: string;
+    };
 
     if (!url || typeof url !== 'string') {
       throw new Error('url parameter is required and must be a string');
@@ -142,7 +167,7 @@ export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
     const { getFirefox } = await import('../index.js');
     const firefox = await getFirefox();
 
-    const newIdx = await firefox.createNewPage(url, workspaceId);
+    const newIdx = await firefox.createNewPage(url, workspaceId, callerId);
 
     return successResponse(`✅ new page [${newIdx}] → ${url}`);
   } catch (error) {
@@ -152,7 +177,11 @@ export async function handleNewPage(args: unknown): Promise<McpToolResponse> {
 
 export async function handleNavigatePage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { url, workspaceId } = args as { url: string; workspaceId?: string };
+    const { url, workspaceId, callerId } = args as {
+      url: string;
+      workspaceId?: string;
+      callerId?: string;
+    };
 
     if (!url || typeof url !== 'string') {
       throw new Error('url parameter is required and must be a string');
@@ -171,7 +200,7 @@ export async function handleNavigatePage(args: unknown): Promise<McpToolResponse
       throw new Error('No page selected');
     }
 
-    await firefox.navigate(url, workspaceId);
+    await firefox.navigate(url, workspaceId, callerId);
 
     return successResponse(`✅ [${selectedIdx}] → ${url}`);
   } catch (error) {
@@ -181,11 +210,12 @@ export async function handleNavigatePage(args: unknown): Promise<McpToolResponse
 
 export async function handleSelectPage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { pageIdx, url, title, workspaceId } = args as {
+    const { pageIdx, url, title, workspaceId, callerId } = args as {
       pageIdx?: number;
       url?: string;
       title?: string;
       workspaceId?: string;
+      callerId?: string;
     };
 
     const { getFirefox } = await import('../index.js');
@@ -228,7 +258,7 @@ export async function handleSelectPage(args: unknown): Promise<McpToolResponse> 
     }
 
     // Select the tab
-    await firefox.selectTab(selectedIdx, workspaceId);
+    await firefox.selectTab(selectedIdx, workspaceId, callerId);
 
     return successResponse(`✅ selected [${selectedIdx}]`);
   } catch (error) {
@@ -238,7 +268,11 @@ export async function handleSelectPage(args: unknown): Promise<McpToolResponse> 
 
 export async function handleClosePage(args: unknown): Promise<McpToolResponse> {
   try {
-    const { pageIdx, workspaceId } = args as { pageIdx: number; workspaceId?: string };
+    const { pageIdx, workspaceId, callerId } = args as {
+      pageIdx: number;
+      workspaceId?: string;
+      callerId?: string;
+    };
 
     if (typeof pageIdx !== 'number') {
       throw new Error('pageIdx parameter is required and must be a number');
@@ -256,7 +290,7 @@ export async function handleClosePage(args: unknown): Promise<McpToolResponse> {
       throw new Error(`Page with index ${pageIdx} not found`);
     }
 
-    await firefox.closeTab(pageIdx, workspaceId);
+    await firefox.closeTab(pageIdx, workspaceId, callerId);
 
     return successResponse(`✅ closed [${pageIdx}]`);
   } catch (error) {

--- a/tests/integration/tabs.integration.test.ts
+++ b/tests/integration/tabs.integration.test.ts
@@ -174,6 +174,13 @@ describe('Tab Management Integration Tests', () => {
     expect(firefox.getSelectedTabIdx(humanWorkspaceId)).toBe(humanTabIndex);
     expect(firefox.getSelectedTabIdx(agentWorkspaceId)).toBe(agentTabIndex);
 
+    await firefox.refreshTabs();
+    const tabs = firefox.getTabs();
+    const agentTab = tabs[agentTabIndex];
+    expect(agentTab?.tabId).toBeDefined();
+    expect(agentTab?.ownership).toBe('agent-owned');
+    expect(agentTab?.ownerWorkspaceId).toBe(agentWorkspaceId);
+
     const humanSnapshot = await firefox.takeSnapshot(undefined, humanWorkspaceId);
     const humanHasClickButton = humanSnapshot.json.uidMap.some(
       (entry) => entry.css.includes('#clickBtn') || entry.css.includes('clickBtn')
@@ -217,6 +224,11 @@ describe('Tab Management Integration Tests', () => {
     const agentTabIndex = await firefox.createNewPage(formPath, agentWorkspaceId);
     await waitForPageLoad();
 
+    await firefox.refreshTabs();
+    const tabsBeforeClose = firefox.getTabs();
+    const agentTabIdBeforeClose = tabsBeforeClose[agentTabIndex]?.tabId;
+    expect(agentTabIdBeforeClose).toBeDefined();
+
     const agentSnapshotBefore = await firefox.takeSnapshot(undefined, agentWorkspaceId);
     const agentEmailElement = agentSnapshotBefore.json.uidMap.find(
       (entry) => entry.css.includes('#email') || entry.css.includes('email')
@@ -228,6 +240,13 @@ describe('Tab Management Integration Tests', () => {
 
     const agentSelectedTabIndex = firefox.getSelectedTabIdx(agentWorkspaceId);
     expect(agentSelectedTabIndex).toBeGreaterThanOrEqual(0);
+
+    await firefox.refreshTabs();
+    const tabsAfterClose = firefox.getTabs();
+    const currentAgentTab = tabsAfterClose[agentSelectedTabIndex];
+    expect(currentAgentTab?.tabId).toBe(agentTabIdBeforeClose);
+    expect(currentAgentTab?.ownership).toBe('agent-owned');
+    expect(currentAgentTab?.ownerWorkspaceId).toBe(agentWorkspaceId);
 
     const agentSnapshotAfter = await firefox.takeSnapshot(undefined, agentWorkspaceId);
     const agentStillHasEmailField = agentSnapshotAfter.json.uidMap.some(

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -2,16 +2,28 @@
  * Unit tests for pages tools
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   listPagesTool,
   selectPageTool,
   navigatePageTool,
   newPageTool,
   closePageTool,
+  handleNavigatePage,
+  handleNewPage,
 } from '../../src/tools/pages.js';
 
+const mockGetFirefox = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/index.js', () => ({
+  getFirefox: () => mockGetFirefox(),
+}));
+
 describe('Pages Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('Tool Definitions', () => {
     it('should have correct tool names', () => {
       expect(listPagesTool.name).toBe('list_pages');
@@ -45,6 +57,7 @@ describe('Pages Tools', () => {
       expect(properties?.pageIdx).toBeDefined();
       expect(properties?.url).toBeDefined();
       expect(properties?.title).toBeDefined();
+      expect(properties?.callerId).toBeDefined();
     });
 
     it('navigatePageTool should require url', () => {
@@ -52,19 +65,67 @@ describe('Pages Tools', () => {
       expect(properties).toBeDefined();
       expect(properties?.url).toBeDefined();
       expect(properties?.url.type).toBe('string');
+      expect(properties?.callerId).toBeDefined();
     });
 
     it('newPageTool should accept url', () => {
       const { properties } = newPageTool.inputSchema;
       expect(properties).toBeDefined();
       expect(properties?.url).toBeDefined();
+      expect(properties?.callerId).toBeDefined();
     });
 
     it('closePageTool should require pageIdx', () => {
       const { properties, required } = closePageTool.inputSchema;
       expect(properties).toBeDefined();
       expect(properties?.pageIdx).toBeDefined();
+      expect(properties?.callerId).toBeDefined();
       expect(required).toContain('pageIdx');
+    });
+  });
+
+  describe('Caller-aware handlers', () => {
+    it('should deny agent navigation into the human workspace by default', async () => {
+      mockGetFirefox.mockResolvedValue({
+        refreshTabs: vi.fn().mockResolvedValue(undefined),
+        getTabs: vi.fn().mockReturnValue([{ title: 'Human Tab', url: 'about:blank' }]),
+        getSelectedTabIdx: vi.fn().mockReturnValue(0),
+        navigate: vi
+          .fn()
+          .mockRejectedValue(
+            new Error(
+              'Caller "agent-b" is not allowed to act in the human workspace without explicit approval'
+            )
+          ),
+      });
+
+      const result = await handleNavigatePage({
+        url: 'https://example.com',
+        workspaceId: 'human',
+        callerId: 'agent-b',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('not allowed to act in the human workspace');
+    });
+
+    it('should deny creating a page in another agent workspace by default', async () => {
+      mockGetFirefox.mockResolvedValue({
+        createNewPage: vi
+          .fn()
+          .mockRejectedValue(
+            new Error('Caller "agent-b" is not allowed to act in workspace "agent-a" by default')
+          ),
+      });
+
+      const result = await handleNewPage({
+        url: 'https://example.com',
+        workspaceId: 'agent-a',
+        callerId: 'agent-b',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('not allowed to act in workspace "agent-a"');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add the first workspace ownership slice on top of workspace-scoped state
- introduce stable Firewatch-side `tabId` metadata plus ownership state for tabs
- add initial deny-by-default caller vs workspace access rules for page-management actions
- document the ownership model and update the tracker

## What changed
- add `shared`, `human-owned`, and `agent-owned` ownership semantics to the docs
- keep `shared` as the default and treat ownership as a protection/override layer
- track stable Firewatch-side `tabId` values independently of mutable tab indices
- assign `agent-owned` ownership to agent-created tabs
- expose `tabId` and ownership info in `list_pages`
- require `callerId` on the current page-management tool surface when a client wants non-human access semantics
- deny agent access to the human workspace by default
- deny agent access to another agent workspace by default
- preserve workspace tab identity after lower-index tab closure

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:run -- tests/tools/pages.test.ts tests/integration/tabs.integration.test.ts tests/tools/text-extraction.test.ts tests/tools/input.test.ts tests/tools/screenshot.test.ts tests/tools/utilities.test.ts`
- `npm run test:run -- tests/integration/tabs.integration.test.ts` (outside sandbox for geckodriver port binding)

## Notes
- this is the first ownership slice, not the full approval/onboarding model
- caller-aware enforcement is currently wired through the page-management surface first
- workspace registry / server-generated workspace ids remains follow-up work in `#29`

Closes #28